### PR TITLE
rosdistro sync, Sun Mar  2 14:49:24 2025

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -37,8 +37,12 @@ jobs:
               echo "username=lopsided98"
               echo "password=${SUPERFLORE_GITHUB_TOKEN}"
             }; f'
-          superflore-gen-nix \
+          superflore-gen-nix --dry-run \
             --tar-archive-dir "${{ runner.temp }}/tar" \
             --output-repository-path . \
             --upstream-branch develop \
             --all
+          ./maintainers/scripts/update-ament-vendor.sh -1
+          git commit -m 'Update vendored-source.json files' $(find -name vendored-source.json) || :
+          superflore-gen-nix --pr-only \
+            --output-repository-path .

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -46,10 +46,10 @@ jobs:
             --output-repository-path . \
             --upstream-branch develop \
             --ros-distro jazzy
-      - name: Update ament_vendor info
-        run: |
-          NIX_PATH=nixpkgs=$PWD ./maintainers/scripts/update-ament-vendor.sh -1
-          git commit -m 'Update vendored-source.json files' $(find -name vendored-source.json) || :
+#       - name: Update ament_vendor info
+#         run: |
+#           NIX_PATH=nixpkgs=$PWD ./maintainers/scripts/update-ament-vendor.sh -1
+#           git commit -m 'Update vendored-source.json files' $(find -name vendored-source.json) || :
       - name: Create PR
         run: |
           superflore-gen-nix --pr-only \

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -43,6 +43,7 @@ jobs:
             --upstream-branch develop \
             --ros-distro jazzy
       - name: Update ament_vendor info
+        continue-on-error: true
         run: |
           # permittedInsecurePackages needed for updating of some gz-*-vendor packages
           mkdir -p ~/.config/nixpkgs
@@ -56,7 +57,6 @@ jobs:
           # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#about-workflow-events
           SUPERFLORE_GITHUB_TOKEN: ${{ secrets.SUPERFLORE_GITHUB_TOKEN }}
         run: |
-          ls -lA
           superflore-gen-nix --pr-only \
             --output-repository-path . \
             --upstream-branch develop \

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -8,8 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: develop
       - uses: cachix/install-nix-action@v22
       - uses: cachix/cachix-action@v12
         with:

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -48,7 +48,7 @@ jobs:
           # permittedInsecurePackages needed for updating of some gz-*-vendor packages
           mkdir -p ~/.config/nixpkgs
           echo '{ permittedInsecurePackages = [ "freeimage-unstable-2021-11-01" ]; }' > ~/.config/nixpkgs/config.nix
-          NIX_PATH=nixpkgs=$PWD ./maintainers/scripts/update-ament-vendor.sh -1
+          NIX_PATH=nixpkgs=$PWD ./maintainers/scripts/update-ament-vendor.sh
           git commit -m 'Update vendored-source.json files' $(find -name vendored-source.json) || :
       - name: Create PR
         env:

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -37,11 +37,13 @@ jobs:
               echo "username=lopsided98"
               echo "password=${SUPERFLORE_GITHUB_TOKEN}"
             }; f'
+          pwd
+          ls -l
           superflore-gen-nix --dry-run \
             --tar-archive-dir "${{ runner.temp }}/tar" \
             --output-repository-path . \
             --upstream-branch develop \
-            --all
+            --ros-distro jazzy --only gz_math_vendor
           ./maintainers/scripts/update-ament-vendor.sh -1
           git commit -m 'Update vendored-source.json files' $(find -name vendored-source.json) || :
           superflore-gen-nix --pr-only \

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -13,6 +13,12 @@ jobs:
         with:
           name: wentasah
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - name: Cache tars
+        uses: actions/cache@v4
+        with:
+          key: tars
+          path: |
+            ~/.ros/tar
       - name: Install Superflore
         run: |
           nix-env -f . -iA python3Packages.rosdep superflore
@@ -36,7 +42,7 @@ jobs:
               echo "password=${SUPERFLORE_GITHUB_TOKEN}"
             }; f'
           superflore-gen-nix --dry-run \
-            --tar-archive-dir "${{ runner.temp }}/tar" \
+            --tar-archive-dir ~/.ros/tar \
             --output-repository-path . \
             --upstream-branch develop \
             --ros-distro jazzy

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -24,10 +24,6 @@ jobs:
           nix-env -f . -iA python3Packages.rosdep superflore
       - name: Update overlay
         env:
-          # Don't use secrets.GITHUB_TOKEN because it prevents the PR from
-          # triggering a build
-          # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#about-workflow-events
-          SUPERFLORE_GITHUB_TOKEN: ${{ secrets.SUPERFLORE_GITHUB_TOKEN }}
           ROS_OS_OVERRIDE: nixos
           ROSDEP_SOURCE_PATH: rosdep-sources
         run: |
@@ -51,6 +47,11 @@ jobs:
 #           NIX_PATH=nixpkgs=$PWD ./maintainers/scripts/update-ament-vendor.sh -1
 #           git commit -m 'Update vendored-source.json files' $(find -name vendored-source.json) || :
       - name: Create PR
+        env:
+          # Don't use secrets.GITHUB_TOKEN because it prevents the PR from
+          # triggering a build
+          # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#about-workflow-events
+          SUPERFLORE_GITHUB_TOKEN: ${{ secrets.SUPERFLORE_GITHUB_TOKEN }}
         run: |
           superflore-gen-nix --pr-only \
             --output-repository-path .

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -55,4 +55,5 @@ jobs:
         run: |
           ls -lA
           superflore-gen-nix --pr-only \
-            --output-repository-path .
+            --output-repository-path . \
+            --upstream-branch develop \

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -46,12 +46,13 @@ jobs:
 #         run: |
 #           NIX_PATH=nixpkgs=$PWD ./maintainers/scripts/update-ament-vendor.sh -1
 #           git commit -m 'Update vendored-source.json files' $(find -name vendored-source.json) || :
-#       - name: Create PR
-#         env:
-#           # Don't use secrets.GITHUB_TOKEN because it prevents the PR from
-#           # triggering a build
-#           # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#about-workflow-events
-#           SUPERFLORE_GITHUB_TOKEN: ${{ secrets.SUPERFLORE_GITHUB_TOKEN }}
-#         run: |
-#           superflore-gen-nix --pr-only \
-#             --output-repository-path .
+      - name: Create PR
+        env:
+          # Don't use secrets.GITHUB_TOKEN because it prevents the PR from
+          # triggering a build
+          # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#about-workflow-events
+          SUPERFLORE_GITHUB_TOKEN: ${{ secrets.SUPERFLORE_GITHUB_TOKEN }}
+        run: |
+          ls -lA
+          superflore-gen-nix --pr-only \
+            --output-repository-path .

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v22
-      - uses: cachix/cachix-action@v12
+      - uses: cachix/cachix-action@v15
         with:
           name: wentasah
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -42,10 +42,13 @@ jobs:
             --output-repository-path . \
             --upstream-branch develop \
             --ros-distro jazzy
-#       - name: Update ament_vendor info
-#         run: |
-#           NIX_PATH=nixpkgs=$PWD ./maintainers/scripts/update-ament-vendor.sh -1
-#           git commit -m 'Update vendored-source.json files' $(find -name vendored-source.json) || :
+      - name: Update ament_vendor info
+        run: |
+          # permittedInsecurePackages needed for updating of some gz-*-vendor packages
+          mkdir -p ~/.config/nixpkgs
+          echo '{ permittedInsecurePackages = [ "freeimage-unstable-2021-11-01" ]; }' > ~/.config/nixpkgs/config.nix
+          NIX_PATH=nixpkgs=$PWD ./maintainers/scripts/update-ament-vendor.sh -1
+          git commit -m 'Update vendored-source.json files' $(find -name vendored-source.json) || :
       - name: Create PR
         env:
           # Don't use secrets.GITHUB_TOKEN because it prevents the PR from

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -35,13 +35,16 @@ jobs:
               echo "username=lopsided98"
               echo "password=${SUPERFLORE_GITHUB_TOKEN}"
             }; f'
-          NIX_PATH=nixpkgs=$PWD ./maintainers/scripts/update-ament-vendor.sh -1
           superflore-gen-nix --dry-run \
             --tar-archive-dir "${{ runner.temp }}/tar" \
             --output-repository-path . \
             --upstream-branch develop \
             --ros-distro jazzy --only gz_math_vendor
+      - name: Update ament_vendor info
+        run: |
           NIX_PATH=nixpkgs=$PWD ./maintainers/scripts/update-ament-vendor.sh -1
           git commit -m 'Update vendored-source.json files' $(find -name vendored-source.json) || :
+      - name: Create PR
+        run: |
           superflore-gen-nix --pr-only \
             --output-repository-path .

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -38,7 +38,8 @@ jobs:
               echo "password=${SUPERFLORE_GITHUB_TOKEN}"
             }; f'
           pwd
-          ls -l
+          ls -lR maintainers
+          ./maintainers/scripts/update-ament-vendor.sh -1
           superflore-gen-nix --dry-run \
             --tar-archive-dir "${{ runner.temp }}/tar" \
             --output-repository-path . \

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -46,12 +46,12 @@ jobs:
 #         run: |
 #           NIX_PATH=nixpkgs=$PWD ./maintainers/scripts/update-ament-vendor.sh -1
 #           git commit -m 'Update vendored-source.json files' $(find -name vendored-source.json) || :
-      - name: Create PR
-        env:
-          # Don't use secrets.GITHUB_TOKEN because it prevents the PR from
-          # triggering a build
-          # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#about-workflow-events
-          SUPERFLORE_GITHUB_TOKEN: ${{ secrets.SUPERFLORE_GITHUB_TOKEN }}
-        run: |
-          superflore-gen-nix --pr-only \
-            --output-repository-path .
+#       - name: Create PR
+#         env:
+#           # Don't use secrets.GITHUB_TOKEN because it prevents the PR from
+#           # triggering a build
+#           # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#about-workflow-events
+#           SUPERFLORE_GITHUB_TOKEN: ${{ secrets.SUPERFLORE_GITHUB_TOKEN }}
+#         run: |
+#           superflore-gen-nix --pr-only \
+#             --output-repository-path .

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -35,15 +35,13 @@ jobs:
               echo "username=lopsided98"
               echo "password=${SUPERFLORE_GITHUB_TOKEN}"
             }; f'
-          pwd
-          ls -lR maintainers
-          ./maintainers/scripts/update-ament-vendor.sh -1
+          NIX_PATH=nixpkgs=$PWD ./maintainers/scripts/update-ament-vendor.sh -1
           superflore-gen-nix --dry-run \
             --tar-archive-dir "${{ runner.temp }}/tar" \
             --output-repository-path . \
             --upstream-branch develop \
             --ros-distro jazzy --only gz_math_vendor
-          ./maintainers/scripts/update-ament-vendor.sh -1
+          NIX_PATH=nixpkgs=$PWD ./maintainers/scripts/update-ament-vendor.sh -1
           git commit -m 'Update vendored-source.json files' $(find -name vendored-source.json) || :
           superflore-gen-nix --pr-only \
             --output-repository-path .

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -39,7 +39,7 @@ jobs:
             --tar-archive-dir "${{ runner.temp }}/tar" \
             --output-repository-path . \
             --upstream-branch develop \
-            --ros-distro jazzy --only gz_math_vendor
+            --ros-distro jazzy
       - name: Update ament_vendor info
         run: |
           NIX_PATH=nixpkgs=$PWD ./maintainers/scripts/update-ament-vendor.sh -1

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -11,8 +11,8 @@ jobs:
       - uses: cachix/install-nix-action@v22
       - uses: cachix/cachix-action@v12
         with:
-          name: ros
-          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+          name: wentasah
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Install Superflore
         run: |
           nix-env -f . -iA python3Packages.rosdep superflore

--- a/distros/jazzy/apriltag/default.nix
+++ b/distros/jazzy/apriltag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, opencv, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-apriltag";
-  version = "3.4.2-r1";
+  version = "3.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag-release/archive/release/jazzy/apriltag/3.4.2-1.tar.gz";
-    name = "3.4.2-1.tar.gz";
-    sha256 = "1451042831b5b0742b24ffb62dd3a97448dfa3a94219b7f912b17f11a7258342";
+    url = "https://github.com/ros2-gbp/apriltag-release/archive/release/jazzy/apriltag/3.4.3-1.tar.gz";
+    name = "3.4.3-1.tar.gz";
+    sha256 = "0c35ac275619056edd82502e894aefb2173457931b1d8e38dc5eca8a6a1ec60a";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/battery-state-broadcaster/default.nix
+++ b/distros/jazzy/battery-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, pluginlib, realtime-tools, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-battery-state-broadcaster";
-  version = "1.0.1-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_battery_monitoring-release/archive/release/jazzy/battery_state_broadcaster/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "bf35e9ca74db0f52ba515087fbf7c8800ef83fa69f789a7c3b897bf8c95bcce5";
+    url = "https://github.com/ros2-gbp/ros_battery_monitoring-release/archive/release/jazzy/battery_state_broadcaster/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "2c50a586c6ec242aa23a3ddc85c61c3b9cd7d774d35989b0e6563ef576b3f63e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/battery-state-rviz-overlay/default.nix
+++ b/distros/jazzy/battery-state-rviz-overlay/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fmt, rclcpp, rviz-2d-overlay-msgs, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-battery-state-rviz-overlay";
-  version = "1.0.1-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_battery_monitoring-release/archive/release/jazzy/battery_state_rviz_overlay/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "d70502f85cf5ce187c8917a88e2e845e66014c7fb093a3f0ab4eb628c9c99fba";
+    url = "https://github.com/ros2-gbp/ros_battery_monitoring-release/archive/release/jazzy/battery_state_rviz_overlay/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "e8823b85013cf4c686803e295214f925f8557774c34f47ee0966521e44e1a11b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/chomp-motion-planner/default.nix
+++ b/distros/jazzy/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-common, moveit-core, rclcpp, rsl, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-chomp-motion-planner";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/chomp_motion_planner/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "e114af3b3d4a346417e74b02b472d776145a07ea328c5766d2450ec02aab94e3";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/chomp_motion_planner/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "84e91c0ba2d053711efae250a0446c3c9339b86f62fe45ac4443d8df8dfe43f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-bridge/default.nix
+++ b/distros/jazzy/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, composition-interfaces, cv-bridge, depthai, depthai-ros-msgs, ffmpeg-image-transport-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-bridge";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_bridge/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "3e85a1f3a4b7a4bc355b5467f1e8f19593b95f5ccdf37d450fa6f622aeb07d62";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_bridge/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "249ad13c5fe5998dc86eab3d615be171d09e099447aa175628f079fc591bc4d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-descriptions/default.nix
+++ b/distros/jazzy/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-descriptions";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_descriptions/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "63a48c01a54e4808f2ce720ad7f3ccde35bf51c1c0b462c9df05db4676ee71c2";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_descriptions/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "1b69c3f8c5e66014e730b709a478b22eeef479e985e67a6ded108264328426b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-examples/default.nix
+++ b/distros/jazzy/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-examples";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_examples/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "7c30c88a1df69793837e2950b068624d546157f97830487aa8917abfee240307";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_examples/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "b22aac60dfb7408ed10656e8a5cdeffb0c2217011e7f749915565d56bb56c2f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-filters/default.nix
+++ b/distros/jazzy/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, depthai-ros-msgs, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-filters";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_filters/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "839b4dde1b2a03c18b60f04debed4d3b1bf14acaace926fb4faaaf5749af7455";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_filters/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "49d6d1e930943ee183b6d2589fc06e2d1cde672d4c36759b3c6b9f0f1654c198";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-ros-driver/default.nix
+++ b/distros/jazzy/depthai-ros-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, ffmpeg-image-transport-msgs, image-pipeline, image-transport, image-transport-plugins, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-ros-driver";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_ros_driver/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "d09e30ec6a1bd8b614c233fa897f53a23814eb2390c838696068773bb80539d3";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_ros_driver/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "84bfdd887a3329f29748cab9e629a19bda1e539bc3ab12e8eab1c44d99c21fd2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-ros-msgs/default.nix
+++ b/distros/jazzy/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-ros-msgs";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_ros_msgs/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "ce85144b6260760cf91277874edbe1ff7d23d84db55902a2e9c590d70e9615cf";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_ros_msgs/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "68b881325e63e9f54d1dcbede3604a4930c00b2da65e1e593d13c828fa3288a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-ros/default.nix
+++ b/distros/jazzy/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-ros";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai-ros/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "bf609d3be53179c159164b29abe0bfd14b61c98235e83f4622294dc02a658724";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai-ros/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "70d6c0007fd407ab37358c2f51e576147c6d1514e4a20f2218445e76d5d04b88";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ds-dbw-can/default.nix
+++ b/distros/jazzy/ds-dbw-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, dataspeed-can-msg-filters, dataspeed-can-usb, ds-dbw-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ds-dbw-can";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw_can/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "238f9b18a6f30bc706f7c224f0fea71194e2fb7e3489161b703c181644d89f95";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw_can/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "6b96df5424654cd03f05bf7be3f69bd195fe0b2cbc0fa2b95e87217dd873b2db";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ds-dbw-joystick-demo/default.nix
+++ b/distros/jazzy/ds-dbw-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ds-dbw-can, ds-dbw-msgs, joy, rclcpp, rclcpp-components, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ds-dbw-joystick-demo";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw_joystick_demo/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "557d357420c8cad8c34524e71dedcda668e2b0de80b98e0cd22533163836509a";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw_joystick_demo/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "31de391777ee10e23313227fba23cfa1a011c6ac1711fc9ade9c3aa60ee746ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ds-dbw-msgs/default.nix
+++ b/distros/jazzy/ds-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ds-dbw-msgs";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw_msgs/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "a869dce0411e0ee25273221de8cbff41a735f77929ecff7cc517bf443198412b";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw_msgs/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "c584f843fa578b491da6eab693e0e2a97568a8ab56249ca1379fca4e7a12e65b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ds-dbw/default.nix
+++ b/distros/jazzy/ds-dbw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ds-dbw-can, ds-dbw-joystick-demo, ds-dbw-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ds-dbw";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "880568f19dda8947e416bec46d462d5610d89af66701bec4186aa85576a869d1";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "4432ba52995dce0e01cc0ec1eeaef95cbd8e3002079126fea3633058d43ea4a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dynamixel-interfaces/default.nix
+++ b/distros/jazzy/dynamixel-interfaces/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-dynamixel-interfaces";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/dynamixel_interfaces-release/archive/release/jazzy/dynamixel_interfaces/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "04f2088d3329e58304cc13299bd0d62c63f8961b35e800ecb19f4f0de6b02caa";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "dynamixel_interfaces contains base messages and service useful for controlling Dynamixel.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/dynamixel-workbench-msgs/default.nix
+++ b/distros/jazzy/dynamixel-workbench-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-dynamixel-workbench-msgs";
-  version = "2.0.3-r5";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_workbench_msgs-release/archive/release/jazzy/dynamixel_workbench_msgs/2.0.3-5.tar.gz";
-    name = "2.0.3-5.tar.gz";
-    sha256 = "9475d98f7df8c05bd66e119efffefc8172743dd799e17ec6ffad7ba04e32e1fe";
+    url = "https://github.com/ros2-gbp/dynamixel_workbench_msgs-release/archive/release/jazzy/dynamixel_workbench_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "110608cd5db8b26c0f15b7100134ffcf0a7716bcc936157ac09727eaa9d31636";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cam-coding/default.nix
+++ b/distros/jazzy/etsi-its-cam-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cam-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "b4f2d0a7eaef9e89fc7f9182bee1afc38cde412644556f773bad5379a62eb7a8";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "89d846d40e27b0fdfe04d823bea59588b7e3f6d963a90d63d9751f650dff2594";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cam-conversion/default.nix
+++ b/distros/jazzy/etsi-its-cam-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cam-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cam-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "b2df3f20ed09fb7995f096c50cead7eb45524e9e1d8bc6ca4d5fc47606c9dfed";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "871d59bec4ce1752497ed71ef1af0fb204886930b02326a394fde6b92deca0e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cam-msgs/default.nix
+++ b/distros/jazzy/etsi-its-cam-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cam-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "3c2881341c1a7d00706dc45cb2c59c858b514c39c32496b221fbd241c87ec5b9";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "403b6e12bbf8273e2a0ac1a42791fe60a8f8145fb5d9ca10bd52f4939072e7cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cam-ts-coding/default.nix
+++ b/distros/jazzy/etsi-its-cam-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cam-ts-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_ts_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "5755b075018065ff1756afef3a0e679ebe39c75f59996d156d7e8aed28ec05c7";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_ts_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "c139021a587db9d4963acab6130659384459599b866160d0efc113c3fac55266";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cam-ts-conversion/default.nix
+++ b/distros/jazzy/etsi-its-cam-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-ts-coding, etsi-its-cam-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cam-ts-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_ts_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "cdeeaefe7dd94cfa7fcbf3890077fa2781f76d2eb0b0b36301fb6126c10ac466";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_ts_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "9948499051860f845de7c105e93b7f78b8b918fc3832dee27eca8a698641d324";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cam-ts-msgs/default.nix
+++ b/distros/jazzy/etsi-its-cam-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cam-ts-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_ts_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "bbd5c099e2c527ea721375bf5c7c67bfcee8f3709c304ca5e7628ed8bbed5129";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_ts_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "658211488c66da395211bb4698ae021d0405e092f12c0f93794bebd2e58f249a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-coding/default.nix
+++ b/distros/jazzy/etsi-its-coding/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cam-ts-coding, etsi-its-cpm-ts-coding, etsi-its-denm-coding, etsi-its-mapem-ts-coding, etsi-its-spatem-ts-coding, etsi-its-vam-ts-coding, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cam-ts-coding, etsi-its-cpm-ts-coding, etsi-its-denm-coding, etsi-its-denm-ts-coding, etsi-its-mapem-ts-coding, etsi-its-spatem-ts-coding, etsi-its-vam-ts-coding, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "0d3e0dc469fc9c3d5903cc467162058182371788a5cd37efb2f9c21ed47dc2ca";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "2e875c0b83f86bee5917b025eed1a24025b27b304daa258ce58a174cd3598e17";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ etsi-its-cam-coding etsi-its-cam-ts-coding etsi-its-cpm-ts-coding etsi-its-denm-coding etsi-its-mapem-ts-coding etsi-its-spatem-ts-coding etsi-its-vam-ts-coding ros-environment ];
+  propagatedBuildInputs = [ etsi-its-cam-coding etsi-its-cam-ts-coding etsi-its-cpm-ts-coding etsi-its-denm-coding etsi-its-denm-ts-coding etsi-its-mapem-ts-coding etsi-its-spatem-ts-coding etsi-its-vam-ts-coding ros-environment ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/etsi-its-conversion/default.nix
+++ b/distros/jazzy/etsi-its-conversion/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-conversion, etsi-its-cam-ts-conversion, etsi-its-cpm-ts-conversion, etsi-its-denm-conversion, etsi-its-mapem-ts-conversion, etsi-its-spatem-ts-conversion, etsi-its-vam-ts-conversion, rclcpp, rclcpp-components, ros-environment, std-msgs, udp-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-conversion, etsi-its-cam-ts-conversion, etsi-its-cpm-ts-conversion, etsi-its-denm-conversion, etsi-its-denm-ts-conversion, etsi-its-mapem-ts-conversion, etsi-its-spatem-ts-conversion, etsi-its-vam-ts-conversion, rclcpp, rclcpp-components, ros-environment, std-msgs, udp-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "eb1a8a009935300fb9b87a7e0c1ed6b3abaa171274472406293a97cb78428e82";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "fdaa24be8f8458f7449bfba0627902f7ffee05b7db36d53972ef5d92e652dfe1";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ etsi-its-cam-conversion etsi-its-cam-ts-conversion etsi-its-cpm-ts-conversion etsi-its-denm-conversion etsi-its-mapem-ts-conversion etsi-its-spatem-ts-conversion etsi-its-vam-ts-conversion rclcpp rclcpp-components ros-environment std-msgs udp-msgs ];
+  propagatedBuildInputs = [ etsi-its-cam-conversion etsi-its-cam-ts-conversion etsi-its-cpm-ts-conversion etsi-its-denm-conversion etsi-its-denm-ts-conversion etsi-its-mapem-ts-conversion etsi-its-spatem-ts-conversion etsi-its-vam-ts-conversion rclcpp rclcpp-components ros-environment std-msgs udp-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/etsi-its-cpm-ts-coding/default.nix
+++ b/distros/jazzy/etsi-its-cpm-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cpm-ts-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cpm_ts_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "8721b1f232b6c58863d858e34d5df7fd1ddf254960e9d885da6db389e43c45a1";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cpm_ts_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "b27eeaac6f43a0f7305829e12e77144341d4a778c7bf307e04a1c08b0fd77f0f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cpm-ts-conversion/default.nix
+++ b/distros/jazzy/etsi-its-cpm-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cpm-ts-coding, etsi-its-cpm-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cpm-ts-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cpm_ts_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "fd8eb11b321c4ef8b962d0b0c43a1e8d242d5cf85fd4eb8982f217f09aba0408";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cpm_ts_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "e3ed1de15125665540260a40187e594975967449414c2bb2baed232f4890981d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cpm-ts-msgs/default.nix
+++ b/distros/jazzy/etsi-its-cpm-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cpm-ts-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cpm_ts_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "619856e20dbcd3177cd8c33bb0716e9946427233bef99529b1cb7422796702a4";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cpm_ts_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "52ad51fe957130ba51cd36df23f90b9dc11e139cc0d2ea2228916a996c0855ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-denm-coding/default.nix
+++ b/distros/jazzy/etsi-its-denm-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-denm-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "adaaeb3c1cdb7b206eeaab392aedafe875dedd6eee66ee58ab3461e135f6604c";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "dda9cd2f5189299a4f2bd272e80ff5e0fa7d943f45aaa245affbf9f6e1f5554b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-denm-conversion/default.nix
+++ b/distros/jazzy/etsi-its-denm-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-denm-coding, etsi-its-denm-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-denm-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "961b0f8db3ecc3b8cf8899d9d3ac911f1f8a428b298aa882faed9672752e6858";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "e2f70ad87b3a44e093ecd07305ae563bde90f9cedc099882a5a4c62b99afebf5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-denm-msgs/default.nix
+++ b/distros/jazzy/etsi-its-denm-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-denm-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "235ee107da997de219075a7c89c53f3d7469df727fc370280bec511cc2f1430b";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "51c2238a3d3040770d4777362590e8d5f918109fed4b310cff6368fe024d564a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-denm-ts-coding/default.nix
+++ b/distros/jazzy/etsi-its-denm-ts-coding/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
+buildRosPackage {
+  pname = "ros-jazzy-etsi-its-denm-ts-coding";
+  version = "3.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_ts_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "1ca6a9307c29790ceb8572cfdd4f0be4b73add9210ed7bf9fe3938ab9a0df494";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "C++ compatible C source code for ETSI ITS DENMs (TS) generated from ASN.1 using asn1c";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/etsi-its-denm-ts-conversion/default.nix
+++ b/distros/jazzy/etsi-its-denm-ts-conversion/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-denm-ts-coding, etsi-its-denm-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
+buildRosPackage {
+  pname = "ros-jazzy-etsi-its-denm-ts-conversion";
+  version = "3.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_ts_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "62c79e767e78b20a3bc7cd9e243c06a47310c9fc801f37aeac2d73c05818470a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-denm-ts-coding etsi-its-denm-ts-msgs etsi-its-primitives-conversion ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Conversion functions for converting ROS messages to and from ASN.1-encoded ETSI ITS DENMs (TS)";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/etsi-its-denm-ts-msgs/default.nix
+++ b/distros/jazzy/etsi-its-denm-ts-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-etsi-its-denm-ts-msgs";
+  version = "3.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_ts_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "7b1d27eb13a11fb9c7d0079219e2d3e883f043c4f6a9c58ea7323a4b9b20f64f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ ros-environment rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = "ROS messages for ETSI ITS DENM (TS)";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/etsi-its-mapem-ts-coding/default.nix
+++ b/distros/jazzy/etsi-its-mapem-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-mapem-ts-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_mapem_ts_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "1fe753540b1a47f4002af9b35b41de829fc7db6a86f148254653bd3bbbd258c1";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_mapem_ts_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "22302214079867e704fbcbbe68f06c471a2fb03858e782cc3efd9f83db1e67fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-mapem-ts-conversion/default.nix
+++ b/distros/jazzy/etsi-its-mapem-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-mapem-ts-coding, etsi-its-mapem-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-mapem-ts-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_mapem_ts_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "911707ecef2b7c37e5565ae8c5018b3355592ce7207de09e289db33e6f069e64";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_mapem_ts_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "0a2f1e80ff36e398735f9fa009cc3ffa9c86b74fd6f256a43416bab3e86a9ba8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-mapem-ts-msgs/default.nix
+++ b/distros/jazzy/etsi-its-mapem-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-mapem-ts-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_mapem_ts_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "ea12cabce14357246b95f51befc4d5e11f66e60d6a08774ddc14d6b81fd8698b";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_mapem_ts_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "0b0ede539fbc7c489c1ff2d2014f980f711bcd82f8e460a515e1ee5168168a31";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-messages/default.nix
+++ b/distros/jazzy/etsi-its-messages/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-coding, etsi-its-conversion, etsi-its-msgs, etsi-its-msgs-utils, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-messages";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_messages/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "0d15b1ba13a416c51ec214cad852f369c08e21a68c912328459691da92852c50";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_messages/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "026c4be6bcada9f3a093760262e87e4acfc7a395716896d9947bd9d868ed29a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-msgs-utils/default.nix
+++ b/distros/jazzy/etsi-its-msgs-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-msgs, geographiclib, geometry-msgs, ros-environment, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-msgs-utils";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_msgs_utils/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "8b3c67e87b0b85a35d6f6fc7f17745ca2386984cc741eea0ff5a9ec403f422d2";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_msgs_utils/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "ef4e52e6ac74e651a1f4a2c117450b598834e6a465227f67ed87204cfa5d6735";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-msgs/default.nix
+++ b/distros/jazzy/etsi-its-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-msgs, etsi-its-cam-ts-msgs, etsi-its-cpm-ts-msgs, etsi-its-denm-msgs, etsi-its-mapem-ts-msgs, etsi-its-spatem-ts-msgs, etsi-its-vam-ts-msgs, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-msgs, etsi-its-cam-ts-msgs, etsi-its-cpm-ts-msgs, etsi-its-denm-msgs, etsi-its-denm-ts-msgs, etsi-its-mapem-ts-msgs, etsi-its-spatem-ts-msgs, etsi-its-vam-ts-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "de9602625c8f63f332e6fb698f26c787ae8a20186bab454f93fde397e9f92aeb";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "1ccec098e1e39b945f7b6ed4542a3a948ebb2c5ace3b00ccc7ee995f6d004584";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ etsi-its-cam-msgs etsi-its-cam-ts-msgs etsi-its-cpm-ts-msgs etsi-its-denm-msgs etsi-its-mapem-ts-msgs etsi-its-spatem-ts-msgs etsi-its-vam-ts-msgs ros-environment ];
+  propagatedBuildInputs = [ etsi-its-cam-msgs etsi-its-cam-ts-msgs etsi-its-cpm-ts-msgs etsi-its-denm-msgs etsi-its-denm-ts-msgs etsi-its-mapem-ts-msgs etsi-its-spatem-ts-msgs etsi-its-vam-ts-msgs ros-environment ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/etsi-its-primitives-conversion/default.nix
+++ b/distros/jazzy/etsi-its-primitives-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-primitives-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_primitives_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "1d6ac2adca68f89016d0518cb5dbb62d1cf154a981ae2059ab42face8cb18631";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_primitives_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "7f9e5c0884f4d1fca17b563b45a23f04b98d294665d0c07cd557f724699cf0b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-rviz-plugins/default.nix
+++ b/distros/jazzy/etsi-its-rviz-plugins/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-msgs, etsi-its-msgs-utils, pluginlib, python3Packages, qt5, rclcpp, ros-environment, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz-satellite, rviz2, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-msgs, etsi-its-cpm-ts-msgs, etsi-its-denm-msgs, etsi-its-mapem-ts-msgs, etsi-its-msgs-utils, etsi-its-spatem-ts-msgs, pluginlib, python3Packages, qt5, rclcpp, ros-environment, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz-satellite, rviz2, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-rviz-plugins";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_rviz_plugins/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "0a791ba308da362c1fd2840be21820c25d3c13c0bb0a550629e5014867f96e65";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_rviz_plugins/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "4ef14ee5c2034e40a5a91384464f41e2f3775aed2c4e26a7b751680018af17d1";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ etsi-its-msgs etsi-its-msgs-utils pluginlib python3Packages.pyproj qt5.qtbase rclcpp ros-environment rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering rviz-satellite rviz2 tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ etsi-its-cam-msgs etsi-its-cpm-ts-msgs etsi-its-denm-msgs etsi-its-mapem-ts-msgs etsi-its-msgs-utils etsi-its-spatem-ts-msgs pluginlib python3Packages.pyproj qt5.qtbase rclcpp ros-environment rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering rviz-satellite rviz2 tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/etsi-its-spatem-ts-coding/default.nix
+++ b/distros/jazzy/etsi-its-spatem-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-spatem-ts-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_spatem_ts_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "83f9f9179a1543b592899a62fa2cccbc1ba28699ee09c2735c00b3928107f395";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_spatem_ts_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "793ed6f8eb6c8cb3d52ab3602266ea02c0d91d26c12a60dd32cd7024985b70f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-spatem-ts-conversion/default.nix
+++ b/distros/jazzy/etsi-its-spatem-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-primitives-conversion, etsi-its-spatem-ts-coding, etsi-its-spatem-ts-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-spatem-ts-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_spatem_ts_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "d92a7b0103796bdeeaf57354001fbfbc651de52d68a98ecb7cbc1bacd6e30382";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_spatem_ts_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "a4cb577c358d9f6b36cccc1d89eaff73f9d733155450ac0be3a317ba4d5efd7b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-spatem-ts-msgs/default.nix
+++ b/distros/jazzy/etsi-its-spatem-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-spatem-ts-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_spatem_ts_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "348be6f71e6f81d8f0d2921b9a9f6cc80ab46c7adc7411f420d515baf3338a0f";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_spatem_ts_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "8c0dc8e3520f328977856022b66e856cce7485bad93fe9b5ec1d6663c80b7d0e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-vam-ts-coding/default.nix
+++ b/distros/jazzy/etsi-its-vam-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-vam-ts-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_vam_ts_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "0107f2ff566e693625d27cad4dec6760e978df3f17fa50c29db6dd1027dc5a2d";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_vam_ts_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "88cfe5e85c82da05793a870c7c37b12ea1df0ecacbebf9b00fc55e1a617851ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-vam-ts-conversion/default.nix
+++ b/distros/jazzy/etsi-its-vam-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-primitives-conversion, etsi-its-vam-ts-coding, etsi-its-vam-ts-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-vam-ts-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_vam_ts_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "147c1d62d84f375c0b7642a529600ee1ca8a41b5d7f68880b51ec0b9bd767dac";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_vam_ts_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "7ce081829517a68de6a5b6a678345ee1cba7190ae2bfa44c8a2c9aa5c9e979c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-vam-ts-msgs/default.nix
+++ b/distros/jazzy/etsi-its-vam-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-vam-ts-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_vam_ts_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "95efef366cf189ae8dfb11c8b49df659767814b80835740030b5ef7786d0f685";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_vam_ts_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "3fd2ac102a9451f582599aaec2c48c47388c22879f0080653d7f9f18c9e694c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/fastrtps/default.nix
+++ b/distros/jazzy/fastrtps/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.14.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/jazzy/fastrtps/2.14.4-1.tar.gz";
+    url = "https://github.com/ros2-gbp/fastdds-release/archive/release/jazzy/fastrtps/2.14.4-1.tar.gz";
     name = "2.14.4-1.tar.gz";
     sha256 = "d4e9b39d38d0a6db4296089c12cdf385d50b02061c74c8927e1fc57f2bb1f9c1";
   };

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -182,8 +182,6 @@ self: super: {
 
  async-web-server-cpp = self.callPackage ./async-web-server-cpp {};
 
- automatika-ros-sugar = self.callPackage ./automatika-ros-sugar {};
-
  automotive-autonomy-msgs = self.callPackage ./automotive-autonomy-msgs {};
 
  automotive-navigation-msgs = self.callPackage ./automotive-navigation-msgs {};
@@ -374,8 +372,6 @@ self: super: {
 
  clearpath-ros2-socketcan-interface = self.callPackage ./clearpath-ros2-socketcan-interface {};
 
- clearpath-sensors-description = self.callPackage ./clearpath-sensors-description {};
-
  clearpath-viz = self.callPackage ./clearpath-viz {};
 
  clips-vendor = self.callPackage ./clips-vendor {};
@@ -554,6 +550,8 @@ self: super: {
 
  dynamixel-hardware = self.callPackage ./dynamixel-hardware {};
 
+ dynamixel-interfaces = self.callPackage ./dynamixel-interfaces {};
+
  dynamixel-sdk = self.callPackage ./dynamixel-sdk {};
 
  dynamixel-sdk-custom-interfaces = self.callPackage ./dynamixel-sdk-custom-interfaces {};
@@ -677,6 +675,12 @@ self: super: {
  etsi-its-denm-conversion = self.callPackage ./etsi-its-denm-conversion {};
 
  etsi-its-denm-msgs = self.callPackage ./etsi-its-denm-msgs {};
+
+ etsi-its-denm-ts-coding = self.callPackage ./etsi-its-denm-ts-coding {};
+
+ etsi-its-denm-ts-conversion = self.callPackage ./etsi-its-denm-ts-conversion {};
+
+ etsi-its-denm-ts-msgs = self.callPackage ./etsi-its-denm-ts-msgs {};
 
  etsi-its-mapem-ts-coding = self.callPackage ./etsi-its-mapem-ts-coding {};
 
@@ -995,6 +999,8 @@ self: super: {
  hash-library-vendor = self.callPackage ./hash-library-vendor {};
 
  heaphook = self.callPackage ./heaphook {};
+
+ hebi-cpp-api = self.callPackage ./hebi-cpp-api {};
 
  hls-lfcd-lds-driver = self.callPackage ./hls-lfcd-lds-driver {};
 
@@ -1323,6 +1329,8 @@ self: super: {
  mola-common = self.callPackage ./mola-common {};
 
  mola-demos = self.callPackage ./mola-demos {};
+
+ mola-gnss-to-markers = self.callPackage ./mola-gnss-to-markers {};
 
  mola-imu-preintegration = self.callPackage ./mola-imu-preintegration {};
 
@@ -1664,6 +1672,10 @@ self: super: {
 
  novatel-gps-msgs = self.callPackage ./novatel-gps-msgs {};
 
+ novatel-oem7-driver = self.callPackage ./novatel-oem7-driver {};
+
+ novatel-oem7-msgs = self.callPackage ./novatel-oem7-msgs {};
+
  ntpd-driver = self.callPackage ./ntpd-driver {};
 
  ntrip-client = self.callPackage ./ntrip-client {};
@@ -1725,8 +1737,6 @@ self: super: {
  pal-statistics = self.callPackage ./pal-statistics {};
 
  pal-statistics-msgs = self.callPackage ./pal-statistics-msgs {};
-
- pangolin = self.callPackage ./pangolin {};
 
  parallel-gripper-controller = self.callPackage ./parallel-gripper-controller {};
 
@@ -2682,6 +2692,8 @@ self: super: {
 
  swri-transform-util = self.callPackage ./swri-transform-util {};
 
+ synapticon-ros2-control = self.callPackage ./synapticon-ros2-control {};
+
  system-fingerprint = self.callPackage ./system-fingerprint {};
 
  system-modes = self.callPackage ./system-modes {};
@@ -2950,8 +2962,6 @@ self: super: {
 
  velodyne = self.callPackage ./velodyne {};
 
- velodyne-description = self.callPackage ./velodyne-description {};
-
  velodyne-driver = self.callPackage ./velodyne-driver {};
 
  velodyne-laserscan = self.callPackage ./velodyne-laserscan {};
@@ -2959,8 +2969,6 @@ self: super: {
  velodyne-msgs = self.callPackage ./velodyne-msgs {};
 
  velodyne-pointcloud = self.callPackage ./velodyne-pointcloud {};
-
- velodyne-simulator = self.callPackage ./velodyne-simulator {};
 
  vision-msgs = self.callPackage ./vision-msgs {};
 
@@ -2990,9 +2998,13 @@ self: super: {
 
  webots-ros2-control = self.callPackage ./webots-ros2-control {};
 
+ webots-ros2-crazyflie = self.callPackage ./webots-ros2-crazyflie {};
+
  webots-ros2-driver = self.callPackage ./webots-ros2-driver {};
 
  webots-ros2-epuck = self.callPackage ./webots-ros2-epuck {};
+
+ webots-ros2-husarion = self.callPackage ./webots-ros2-husarion {};
 
  webots-ros2-importer = self.callPackage ./webots-ros2-importer {};
 

--- a/distros/jazzy/gz-cmake-vendor/vendored-source.json
+++ b/distros/jazzy/gz-cmake-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-cmake.git",
+  "rev": "gz-cmake3_3.5.4",
+  "hash": "sha256-mP0bBPWWAoUFsUwKn95Eqv1lW3lJdPEu3hhfmiK3mNQ="
+}

--- a/distros/jazzy/gz-common-vendor/vendored-source.json
+++ b/distros/jazzy/gz-common-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-common.git",
+  "rev": "gz-common5_5.7.1",
+  "hash": "sha256-vNCjCSQYCSUHXKwXnq8vwWXiSK2+cD3yPSLT1FdAWrE="
+}

--- a/distros/jazzy/gz-dartsim-vendor/vendored-source.json
+++ b/distros/jazzy/gz-dartsim-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/dartsim/dart.git",
+  "rev": "v6.13.2",
+  "hash": "sha256-AfKPqUiW6BsM98TIzTY2ZcFP1WvURs8/dGOzanIiB9g="
+}

--- a/distros/jazzy/gz-fuel-tools-vendor/vendored-source.json
+++ b/distros/jazzy/gz-fuel-tools-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-fuel-tools.git",
+  "rev": "gz-fuel-tools9_9.1.1",
+  "hash": "sha256-XQoBcCtzwzzPypS1kIeTCIbjtxrzaW3JvZLCYbwXAOk="
+}

--- a/distros/jazzy/gz-gui-vendor/vendored-source.json
+++ b/distros/jazzy/gz-gui-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-gui.git",
+  "rev": "gz-gui8_8.4.0",
+  "hash": "sha256-gf9XZzAX2g6r9ThIA0v2H2X/+uu9VnwvyvrdL5ZazM0="
+}

--- a/distros/jazzy/gz-launch-vendor/default.nix
+++ b/distros/jazzy/gz-launch-vendor/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, binutils, gflags, gz-cmake-vendor, gz-common-vendor, gz-gui-vendor, gz-math-vendor, gz-msgs-vendor, gz-plugin-vendor, gz-sim-vendor, gz-tools-vendor, gz-transport-vendor, libwebsockets, libyaml, tinyxml-2, util-linux, xorg }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, binutils, cmake, gflags, gz-cmake-vendor, gz-common-vendor, gz-gui-vendor, gz-math-vendor, gz-msgs-vendor, gz-plugin-vendor, gz-sim-vendor, gz-tools-vendor, gz-transport-vendor, libwebsockets, libyaml, tinyxml-2, util-linux, xorg }:
 buildRosPackage {
   pname = "ros-jazzy-gz-launch-vendor";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_launch_vendor-release/archive/release/jazzy/gz_launch_vendor/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "05122a6846b82a7e8df84ae48b8f9393d0c0e23ea7ff2376a8d7bb31a7755020";
+    url = "https://github.com/ros2-gbp/gz_launch_vendor-release/archive/release/jazzy/gz_launch_vendor/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "e1ffffcf4ecf1684ba9560830c17aedf9e25b25734238cd3996f964c9f4c272c";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint xorg.xorgserver ];
   propagatedBuildInputs = [ binutils gflags gz-cmake-vendor gz-common-vendor gz-gui-vendor gz-math-vendor gz-msgs-vendor gz-plugin-vendor gz-sim-vendor gz-tools-vendor gz-transport-vendor libwebsockets libyaml tinyxml-2 util-linux xorg.libXi xorg.libXmu ];
-  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-launch7 7.1.0
+    description = "Vendor package for: gz-launch7 7.1.1
 
     Gazebo Launch : Run and manage programs and plugins";
     license = with lib.licenses; [ asl20 ];

--- a/distros/jazzy/gz-launch-vendor/vendored-source.json
+++ b/distros/jazzy/gz-launch-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-launch.git",
+  "rev": "gz-launch7_7.1.0",
+  "hash": "sha256-En3V8i/Ie8+KnSHGlm9Bap7REdLhYBaVHVbOM+/Pzno="
+}

--- a/distros/jazzy/gz-math-vendor/vendored-source.json
+++ b/distros/jazzy/gz-math-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-math.git",
+  "rev": "gz-math7_7.5.2",
+  "hash": "sha256-LwYeyv8nwX06n5ju+ra2uqNMedMSLRumem8qDHXtNns="
+}

--- a/distros/jazzy/gz-msgs-vendor/default.nix
+++ b/distros/jazzy/gz-msgs-vendor/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, gz-cmake-vendor, gz-math-vendor, gz-tools-vendor, protobuf, python3, python3Packages, tinyxml-2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, gz-math-vendor, gz-tools-vendor, protobuf, python3, python3Packages, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-jazzy-gz-msgs-vendor";
-  version = "0.0.5-r1";
+  version = "0.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_msgs_vendor-release/archive/release/jazzy/gz_msgs_vendor/0.0.5-1.tar.gz";
-    name = "0.0.5-1.tar.gz";
-    sha256 = "f9db0335909fd39e9831fd6424d4da93e1ef1da14874d7dcd23ee467194dedc2";
+    url = "https://github.com/ros2-gbp/gz_msgs_vendor-release/archive/release/jazzy/gz_msgs_vendor/0.0.6-1.tar.gz";
+    name = "0.0.6-1.tar.gz";
+    sha256 = "bb33ebc5f45ec2a53b1dd614e21de00f9f110c409d2517673c139e0cf5e46510";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint python3Packages.pytest ];
   propagatedBuildInputs = [ gz-cmake-vendor gz-math-vendor gz-tools-vendor protobuf python3 python3Packages.protobuf tinyxml-2 ];
-  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-msgs10 10.3.1
+    description = "Vendor package for: gz-msgs10 10.3.2
 
     Gazebo Messages: Protobuf messages and functions for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/jazzy/gz-msgs-vendor/vendored-source.json
+++ b/distros/jazzy/gz-msgs-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-msgs.git",
+  "rev": "gz-msgs10_10.3.1",
+  "hash": "sha256-GBEylFQvR2MWOIivW2+MGy//jjewId41mk8qpLfoaYM="
+}

--- a/distros/jazzy/gz-ogre-next-vendor/vendored-source.json
+++ b/distros/jazzy/gz-ogre-next-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/OGRECave/ogre-next.git",
+  "rev": "v2.3.3",
+  "hash": "sha256-elSj35LwsLzj1ssDPsk9NW/KSXfiOGYmw9hQSAWdpFM="
+}

--- a/distros/jazzy/gz-physics-vendor/vendored-source.json
+++ b/distros/jazzy/gz-physics-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-physics.git",
+  "rev": "gz-physics7_7.5.0",
+  "hash": "sha256-75myTqDeEybvj5rsJxRambLPle1cen6HIatZGbVoXro="
+}

--- a/distros/jazzy/gz-plugin-vendor/vendored-source.json
+++ b/distros/jazzy/gz-plugin-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-plugin.git",
+  "rev": "gz-plugin2_2.0.4",
+  "hash": "sha256-iL4+EdFFAU55FVqE/CvyTv1zNaXxBWqWx44L0BeG2MU="
+}

--- a/distros/jazzy/gz-rendering-vendor/vendored-source.json
+++ b/distros/jazzy/gz-rendering-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-rendering.git",
+  "rev": "gz-rendering8_8.2.2",
+  "hash": "sha256-x+QHn8d+19U12CG1+HEmP0KcM3beY00Vvrc8mrxvAs0="
+}

--- a/distros/jazzy/gz-ros2-control-demos/default.nix
+++ b/distros/jazzy/gz-ros2-control-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, geometry-msgs, gz-ros2-control, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, mecanum-drive-controller, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-bridge, ros-gz-sim, ros2controlcli, ros2launch, std-msgs, tricycle-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-gz-ros2-control-demos";
-  version = "1.2.10-r1";
+  version = "1.2.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/jazzy/gz_ros2_control_demos/1.2.10-1.tar.gz";
-    name = "1.2.10-1.tar.gz";
-    sha256 = "226eca69bb825a9b4fe09b253eefec112f7c329dc60d6a847fb73a7b20ea7201";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/jazzy/gz_ros2_control_demos/1.2.11-1.tar.gz";
+    name = "1.2.11-1.tar.gz";
+    sha256 = "e3001448c7c9b18b42e9f4ef4cd5e3ae771c0c7190321458629a386ff349379b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gz-ros2-control/default.nix
+++ b/distros/jazzy/gz-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-manager, gz-plugin-vendor, gz-sim-vendor, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-gz-ros2-control";
-  version = "1.2.10-r1";
+  version = "1.2.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/jazzy/gz_ros2_control/1.2.10-1.tar.gz";
-    name = "1.2.10-1.tar.gz";
-    sha256 = "cd9593253d6f8b4bf02ca5a9d778f6d61353120e98226fc22422ad43a9331eff";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/jazzy/gz_ros2_control/1.2.11-1.tar.gz";
+    name = "1.2.11-1.tar.gz";
+    sha256 = "f1f59f6bca12705f79cf4947707fd44907dbadfc0bf08eff0c2e4a52440136ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gz-sensors-vendor/vendored-source.json
+++ b/distros/jazzy/gz-sensors-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-sensors.git",
+  "rev": "gz-sensors8_8.2.2",
+  "hash": "sha256-TRDMCMesJXVSVGA3bnRngtXTi4VVf0y12AJQ79EEMiI="
+}

--- a/distros/jazzy/gz-sim-vendor/default.nix
+++ b/distros/jazzy/gz-sim-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, freeglut, freeimage, gbenchmark, glew, gz-cmake-vendor, gz-common-vendor, gz-fuel-tools-vendor, gz-gui-vendor, gz-math-vendor, gz-msgs-vendor, gz-physics-vendor, gz-plugin-vendor, gz-rendering-vendor, gz-sensors-vendor, gz-tools-vendor, gz-transport-vendor, gz-utils-vendor, protobuf, python3Packages, qt5, sdformat-vendor, tinyxml-2, util-linux, xorg }:
 buildRosPackage {
   pname = "ros-jazzy-gz-sim-vendor";
-  version = "0.0.7-r1";
+  version = "0.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_sim_vendor-release/archive/release/jazzy/gz_sim_vendor/0.0.7-1.tar.gz";
-    name = "0.0.7-1.tar.gz";
-    sha256 = "ac1208a853d31c61c39576ac25b355c09dcdbb0b699406aa91cdff99c3bce7c8";
+    url = "https://github.com/ros2-gbp/gz_sim_vendor-release/archive/release/jazzy/gz_sim_vendor/0.0.8-1.tar.gz";
+    name = "0.0.8-1.tar.gz";
+    sha256 = "53b946ba26654cef76ab53fd13e3f3b84806f3cb84c21f0b938360627265c99e";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-sim8 8.8.0
+    description = "Vendor package for: gz-sim8 8.9.0
 
     Gazebo Sim : A Robotic Simulator";
     license = with lib.licenses; [ asl20 ];

--- a/distros/jazzy/gz-sim-vendor/vendored-source.json
+++ b/distros/jazzy/gz-sim-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-sim.git",
+  "rev": "gz-sim8_8.8.0",
+  "hash": "sha256-C3DuM7pnxPoKd9NcmwKbD5n9eDxaJ9T3+wwbH1ZbWmg="
+}

--- a/distros/jazzy/gz-tools-vendor/vendored-source.json
+++ b/distros/jazzy/gz-tools-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-tools.git",
+  "rev": "gz-tools2_2.0.2",
+  "hash": "sha256-CY+W1jWIkszKwKuLgKmJpZMXHn0RnueMHFSDhOXIzLg="
+}

--- a/distros/jazzy/gz-transport-vendor/vendored-source.json
+++ b/distros/jazzy/gz-transport-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-transport.git",
+  "rev": "gz-transport13_13.4.1",
+  "hash": "sha256-hCP+yVoyl1c3KNmQ5jKrYvPT1IlAy9JkCh0c0mOF+KM="
+}

--- a/distros/jazzy/gz-utils-vendor/vendored-source.json
+++ b/distros/jazzy/gz-utils-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-utils.git",
+  "rev": "gz-utils2_2.2.1",
+  "hash": "sha256-utVW8pTP/emEWblTxVb6jzulKdxss+2VfS552MWMqm4="
+}

--- a/distros/jazzy/hebi-cpp-api/default.nix
+++ b/distros/jazzy/hebi-cpp-api/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, eigen }:
+buildRosPackage {
+  pname = "ros-jazzy-hebi-cpp-api";
+  version = "3.12.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/hebi_cpp_api-release/archive/release/jazzy/hebi_cpp_api/3.12.3-1.tar.gz";
+    name = "3.12.3-1.tar.gz";
+    sha256 = "4c6816d54affd2ebb037d18457737cbf9a2d54faecad3f1b666846f957f960ca";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake eigen ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A ROS 2 package providing access to the HEBI C++ API.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/hls-lfcd-lds-driver/default.nix
+++ b/distros/jazzy/hls-lfcd-lds-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-hls-lfcd-lds-driver";
-  version = "2.0.4-r6";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hls_lfcd_lds_driver-release/archive/release/jazzy/hls_lfcd_lds_driver/2.0.4-6.tar.gz";
-    name = "2.0.4-6.tar.gz";
-    sha256 = "188f79b336bd714e8d512e7a8b810f0b9a0c2976084d5609853b622a2f0f2e9f";
+    url = "https://github.com/ros2-gbp/hls_lfcd_lds_driver-release/archive/release/jazzy/hls_lfcd_lds_driver/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "2e3ba07e71a1d2a5042fde3ad9182a0d55c4d2ef3f2dccec9baff069142e4bb5";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "ROS package for LDS(HLS-LFCD2).
+    description = "ROS package for LDS-01(HLS-LFCD2).
     The LDS (Laser Distance Sensor) is a sensor sending the data to Host for the simultaneous localization and mapping (SLAM). Simultaneously the detecting obstacle data can also be sent to Host. HLDS(Hitachi-LG Data Storage) is developing the technology for the moving platform sensor such as Robot Vacuum Cleaners, Home Robot, Robotics Lawn Mower Sensor, etc.";
     license = with lib.licenses; [ bsdOriginal ];
   };

--- a/distros/jazzy/kitti-metrics-eval/default.nix
+++ b/distros/jazzy/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmath, mrpt-libposes, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-jazzy-kitti-metrics-eval";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/kitti_metrics_eval/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "33be2f610d7d2f3a048167c77bd4293034a640a6decf975276efbdeeeb919973";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/kitti_metrics_eval/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "e4cca7f934114dea7dd6c2e3abca7a8bbef7c771d9173cb3f2394fbbb52d5f30";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-bridge-ros2/default.nix
+++ b/distros/jazzy/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, geometry-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-bridge-ros2";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_bridge_ros2/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "5ba2cf8ad8ab374cba8a323932a444c0f8b870af956b74cccd80ff2bf2b86682";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_bridge_ros2/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "49f54780219f063a06be3bf4c288d7862917fd5346b8f1fce3b33d533df3b0b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-demos/default.nix
+++ b/distros/jazzy/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-demos";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_demos/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "5f9fdbbbc4e4e2c9fa4d8b596c5eaab603b77d78a10975738c86b73603cdd207";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_demos/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "fe84c40ea8bdf777fc237b0cd51b356ce487bbb979f4243da9e70c28d00e8e6f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-gnss-to-markers/default.nix
+++ b/distros/jazzy/mola-gnss-to-markers/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-libobs, mrpt-nav-interfaces, rclcpp, std-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-mola-gnss-to-markers";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_gnss_to_markers-release/archive/release/jazzy/mola_gnss_to_markers/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "cb85e9dcaaebca5e4c710d2db5e3d88c24a646089d4a744b6f10be1694576a87";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ mrpt-libobs mrpt-nav-interfaces rclcpp std-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Takes GNSS (GPS) readings, a MOLA georeferenced map, and publishes markers to visualize the datums as ellipsoids on the map";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/jazzy/mola-imu-preintegration/default.nix
+++ b/distros/jazzy/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-imu-preintegration";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_imu_preintegration/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "3b5fedecbfa56daff78178ba09df8afa602520bd48fcf3d37ff6e78e1772c6c6";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_imu_preintegration/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "748b10b41db86f9f50aa0ba045c3b08c48ea7e7e1f43c558dc2c74486cd0b872";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-euroc-dataset/default.nix
+++ b/distros/jazzy/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmath, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-euroc-dataset";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_euroc_dataset/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "72ad120383bcd6bb641c4b5258e6f34faafdbe0cd1a559cd1dfa2e9ed4736a0c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_euroc_dataset/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "08d22aa801376fda04371e1188662d7ce421a014c937e5d4affa6066b7effd16";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-kitti-dataset/default.nix
+++ b/distros/jazzy/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-kitti-dataset";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti_dataset/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "325ffa569319399eaa347812608dd4eb03e50f3258951746f1ea90639b1ad6ab";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti_dataset/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "6c1b52488d8a0e4cb686fd7ad3da78149ef598e3f5899c424f82257fe38c1fad";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-kitti360-dataset/default.nix
+++ b/distros/jazzy/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-kitti360-dataset";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti360_dataset/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "e3ee3865b28de2fa4b257187a501c38df0e8baffb0d30c78ebb93f654fa826fd";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti360_dataset/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "ea2a26d7f44252b1d57d38aff805a0a3e49309a28894af39746e6374eb29aae3";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-mulran-dataset/default.nix
+++ b/distros/jazzy/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-mulran-dataset";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_mulran_dataset/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "348dc083bcecbe773b18d5d2bc071d0d029f2831e6b0909776ecec5a03973222";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_mulran_dataset/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "6e9fd9771009494a865fbe441b0b01dd5b6f9e039d4655ec8a2438eb1582fef7";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-paris-luco-dataset/default.nix
+++ b/distros/jazzy/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-paris-luco-dataset";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_paris_luco_dataset/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "45710d58dffb3ca46f9e6d9684d21d4e250315163864a4e781b7cd2b1a300648";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_paris_luco_dataset/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "ba7151f22fb7d42a9a69a162a1d56572e4d6c849e71f691ba78468af616518a3";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-rawlog/default.nix
+++ b/distros/jazzy/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-rawlog";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rawlog/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "f953e98a1dd10d843c6152055f1f849e6a1a6d21113fa0434056656e380e76d6";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rawlog/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "65c73ee590e63725abee437b48324053dbc9522f710de1767aa7d9d79be772c6";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-rosbag2/default.nix
+++ b/distros/jazzy/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt-libobs, mrpt-libros-bridge, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-rosbag2";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rosbag2/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "39c4a4539da41d8b611ebb47552bcdccb9b34c646b6b27ab9439a02b397b22d0";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rosbag2/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "03dabc68b33c8cb5fb657f68e115d283da113eedb25a27da541e90feaeb87b69";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-kernel/default.nix
+++ b/distros/jazzy/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libgui, mrpt-libmaps, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-kernel";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_kernel/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "c8b3d70d04774696aace196c54faa1ad388b811571bde63382d014015bbca3c7";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_kernel/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "1b76d9ee4bd80cc5115821efbfb8ce669654bd287cb1f094af7d8d6c9ff0578c";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-launcher/default.nix
+++ b/distros/jazzy/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt-libbase, mrpt-libtclap, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-launcher";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_launcher/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "d4f054831ca2a64648873e152e21e7f10ff1f674f4718b940c2226a850f8baa6";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_launcher/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "17352377c09d60f8568655615800e170607342c3f4dfca066cf9d21b4c32c6ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-lidar-odometry/default.nix
+++ b/distros/jazzy/mola-lidar-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-jazzy-mola-lidar-odometry";
-  version = "0.6.1-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/jazzy/mola_lidar_odometry/0.6.1-1.tar.gz";
-    name = "0.6.1-1.tar.gz";
-    sha256 = "2d757f0f591e6cff1b1f39234d90582ce8b0495a65bc8f768329f98e9636d571";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/jazzy/mola_lidar_odometry/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "42d88cc0a535105e0771be3b7b0975e6835c723f2fc4f59d404a7b34a9976e2f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-metric-maps/default.nix
+++ b/distros/jazzy/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mp2p-icp, mrpt-libmaps, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-metric-maps";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_metric_maps/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "0e6e6aca656651e1e4a6877a9f471e38c3a46b4d60737bc7f0e6a64975021c46";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_metric_maps/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "f8327c311d2f975ad2d16d11302ebee43aab21bdb26ad86138d14a494236e6bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-msgs/default.nix
+++ b/distros/jazzy/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-mola-msgs";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_msgs/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "b88023918188f0361ed05c4697b5a56cac2af04e4508499e55bfa5984e0f38b4";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_msgs/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "284e5bb901a780dade92d7bf06538aefe457777be68ee20ed1942ff41a3dad86";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-pose-list/default.nix
+++ b/distros/jazzy/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-jazzy-mola-pose-list";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_pose_list/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "52c41bb5a20427b1be185b675cce032f21c972b4fbc6c711a809a8ad363cab41";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_pose_list/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "a9a704ef6f4da5f175c1704a123dfdabbe771f93b3577581793323ceb2459b04";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-relocalization/default.nix
+++ b/distros/jazzy/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libslam }:
 buildRosPackage {
   pname = "ros-jazzy-mola-relocalization";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_relocalization/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "c856a476e8e05c1f430bb947dd2c67b809fe9b42f12d8a1077a556d024d117ef";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_relocalization/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "af20c49ce7f351138dc4ddd1fb4d57d80920913367d85d7c266f2a52b0a27d5b";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-state-estimation-simple/default.nix
+++ b/distros/jazzy/mola-state-estimation-simple/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-state-estimation-simple";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation_simple/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "6fcebd863d7e79166c5fae43db5ee20090e8c806863cd30c27293307a977e261";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation_simple/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "53e3fd7ffaaebb896cb76cd2d9af8f234f436d511e2e7261ce29a674d1c8656b";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-state-estimation-smoother/default.nix
+++ b/distros/jazzy/mola-state-estimation-smoother/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-state-estimation-smoother";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation_smoother/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "74188eb19febd68be6998571f63a65d4955d72a709f875b1a5e9350b2a2de3bc";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation_smoother/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "bb10b661e2d9fcc9d6474489f7135fad843817f38062d4cc8fb78b8aa066def7";
   };
 
   buildType = "cmake";
-  buildInputs = [ boost cmake gtsam ];
-  propagatedBuildInputs = [ mola-common mola-imu-preintegration mola-kernel mrpt-libobs ];
+  buildInputs = [ boost cmake ];
+  propagatedBuildInputs = [ gtsam mola-common mola-imu-preintegration mola-kernel mrpt-libobs ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/jazzy/mola-state-estimation/default.nix
+++ b/distros/jazzy/mola-state-estimation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, mola-imu-preintegration, mola-state-estimation-simple, mola-state-estimation-smoother }:
 buildRosPackage {
   pname = "ros-jazzy-mola-state-estimation";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "f1086239aaa9fa0951f60df0f5b1c4daa4e25064ea230a7d292091a735696b89";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "072264aa0468da5742376292dd399c3d8e719cb792ad4b25f3c699ed8aaca428";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-traj-tools/default.nix
+++ b/distros/jazzy/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-jazzy-mola-traj-tools";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_traj_tools/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "a86a13ea07c13c19bc4f8fb261ef2c74ad3beafcf16a10a2525708cf112f5bc8";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_traj_tools/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "0e64f5fdad332b0838907b731a30e6b671067d70e2f87a5a93d187f5912f5a00";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-viz/default.nix
+++ b/distros/jazzy/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-jazzy-mola-viz";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_viz/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "701288f3b2d2ee6828b671175981839b3b8c8a83ac47f84b01601b352cba8248";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_viz/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "10c53cd65ac34c20b68c35a7ea3756520818689f82cceae3ab3d2e23c91a8eb0";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-yaml/default.nix
+++ b/distros/jazzy/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase }:
 buildRosPackage {
   pname = "ros-jazzy-mola-yaml";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_yaml/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "3df7d51cf48a6875f94bc5d066d86f61d224b8999a915fe39a2b118e697559e2";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_yaml/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "c72646d1b12aba989451757479f14539e112bd4a0edab797a128cf8930b04ed4";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola/default.nix
+++ b/distros/jazzy/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-jazzy-mola";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "fad49c86f169f7f4b7570f6945f72feba8bbc3efa7326c43b0f2da3e1709e50a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "2d59c09b17d7dc228ea72a973b3c652f7a38a5a58d5c4f36eecf38d387be329c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-common/default.nix
+++ b/distros/jazzy/moveit-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, backward-ros }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-common";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_common/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "8b3c0d8eb2f73cfdb7899389f4e4c8fab8fa3af5250cec6e1c1d972eb2a30465";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_common/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "7d54d5e2b932d5e9b4aff376f07097fa8de81aaad3e7db1c7dd55c43c081a4c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-configs-utils/default.nix
+++ b/distros/jazzy/moveit-configs-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, launch, launch-param-builder, launch-ros, srdfdom }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-configs-utils";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_configs_utils/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "4cb718b1bcbea788179fd75e007198145aadb0b8554b05a404d555149b22d4b7";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_configs_utils/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "40befff1f11c5304c4e8c9090ae1277bd099cf9e535fdeb348423bca96366068";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/moveit-core/default.nix
+++ b/distros/jazzy/moveit-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-index-cpp, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, generate-parameter-library, geometric-shapes, geometry-msgs, google-benchmark-vendor, kdl-parser, launch-testing-ament-cmake, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl-vendor, osqp-vendor, pkg-config, pluginlib, random-numbers, rcl-interfaces, rclcpp, rclpy, rsl, ruckig, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-core";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_core/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "e7ad37e4cdef2ddd3e9046cc71c47feef705216033368cd9391617fed2bd5902";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_core/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "1fbc95ee0053f3f1d7c823fbe39e240397fd3ad3419eba9528b445b3ae9b86fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-hybrid-planning/default.nix
+++ b/distros/jazzy/moveit-hybrid-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, controller-manager, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-planning-interface, moveit-simple-controller-manager, pluginlib, position-controllers, rclcpp, rclcpp-action, rclcpp-components, robot-state-publisher, ros-testing, rviz2, std-msgs, std-srvs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-hybrid-planning";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_hybrid_planning/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "1354484c28dea4665fdc3f3f666d1993f72233544c73fa17b1910fae9fc2c9e6";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_hybrid_planning/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "c73ea6e88d6c60bc4ae920d92ed0d497e33c36005de97f0a6d8ab677b8fc391c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-kinematics/default.nix
+++ b/distros/jazzy/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, class-loader, eigen, generate-parameter-library, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl-vendor, pluginlib, python3Packages, ros-testing, rsl, tf2, tf2-kdl, urdfdom }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-kinematics";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_kinematics/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "96636e12d8b76056ee9f432293802243d7d104c51990f319cc3b12b0ff285b9b";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_kinematics/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "f91ba89541dfb5cd3919a546b986366f769723788f344234e9b9e955dc7c7f8c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-planners-chomp/default.nix
+++ b/distros/jazzy/moveit-planners-chomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, chomp-motion-planner, moveit-common, moveit-core, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-planners-chomp";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_planners_chomp/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "c7584bec2507e3c5d8fcf51ea96165b4215faf5833b090e51b764de181553ddc";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_planners_chomp/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "70a2d5a04d9457ab3c26414a26e5e2676d9f58328f4e070c10d2ff333315f344";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-planners-ompl/default.nix
+++ b/distros/jazzy/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module, llvmPackages, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rclcpp, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-planners-ompl";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_planners_ompl/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "a3de8e12a121958bd0d675c27beaccf0632a9e6949526338007d046fc13ace7f";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_planners_ompl/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "d2714b713beab315ffc32a330cbfa7657b8cea474ea76b2611d3644ae088fa19";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-planners-stomp/default.nix
+++ b/distros/jazzy/moveit-planners-stomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, generate-parameter-library, moveit-common, moveit-core, rsl, std-msgs, stomp, tf2-eigen, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-planners-stomp";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_planners_stomp/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "53c3687d8116a8698d4a59d984098b1dc8330c3b8cd6eefa56d574aa2f8761f0";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_planners_stomp/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "b39178f3a5b924efe75654c9e59b5834f18575475de763c2532692334866d95a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-planners/default.nix
+++ b/distros/jazzy/moveit-planners/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, chomp-motion-planner, moveit-planners-ompl, moveit-planners-stomp, pilz-industrial-motion-planner }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, moveit-planners-chomp, moveit-planners-ompl, moveit-planners-stomp, pilz-industrial-motion-planner }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-planners";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_planners/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "f872e854bfb9ab00a0455c2fbcf347973450d19c19a34bac119f07513bcd75d8";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_planners/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "6c2d30f553f8aeeac72dec3d08052e6a6a29af793526e47c10c3e2db307de6bc";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ chomp-motion-planner moveit-planners-ompl moveit-planners-stomp pilz-industrial-motion-planner ];
+  propagatedBuildInputs = [ moveit-planners-chomp moveit-planners-ompl moveit-planners-stomp pilz-industrial-motion-planner ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/moveit-plugins/default.nix
+++ b/distros/jazzy/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-plugins";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_plugins/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "6cfc5989d6ada4584a585bbf37db9966ec2f21f0b54b934a16b27dfbe6fc6b7a";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_plugins/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "cc0769999637520fcfcbe05d155e509925bbcffae5b5565a406482b19e992fec";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-py/default.nix
+++ b/distros/jazzy/moveit-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, geometry-msgs, moveit-core, moveit-ros-planning, moveit-ros-planning-interface, octomap-msgs, pybind11-vendor, python3Packages, rclcpp, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-py";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_py/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "3860b7b39a64770edc11e184c23ac0a34423a68dead76dc693302715bbd69613";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_py/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "822311f7ebdf0aa614fbf7572acbde98293b896db31f534fac2c52e37b5c7083";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
+++ b/distros/jazzy/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, generate-parameter-library, moveit-core, pluginlib, rclcpp, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-resources-prbt-ikfast-manipulator-plugin";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_resources_prbt_ikfast_manipulator_plugin/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "ce502e8173a2116a6864b2893fe6324067e2a0c570de9c46cc233ae9ef986774";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_resources_prbt_ikfast_manipulator_plugin/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "3c688e9337b892f19c986d2217ce417d4968d6ce7734457b708857895b35c5da";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-resources-prbt-moveit-config/default.nix
+++ b/distros/jazzy/moveit-resources-prbt-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-support, moveit-ros-move-group, robot-state-publisher, rviz2, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-resources-prbt-moveit-config";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_resources_prbt_moveit_config/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "cfa165d07af5807bc1eae5114644e28ee320e2fe91a8a2559ed45273e3e25191";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_resources_prbt_moveit_config/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "6c03f32147c795b725d37810c25dee3bf638578614aafa4dfdc409d7c6d0667c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-resources-prbt-pg70-support/default.nix
+++ b/distros/jazzy/moveit-resources-prbt-pg70-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-moveit-config, moveit-resources-prbt-support, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-resources-prbt-pg70-support";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_resources_prbt_pg70_support/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "c4a697f713ad97431d8e4da7b5a52a3f82b85185e42bc17106783a9b60ac7f6f";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_resources_prbt_pg70_support/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "c07877c576d36c02b0bafb00a7d53318463529e9709aca2e177e047410b10e5a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-resources-prbt-support/default.nix
+++ b/distros/jazzy/moveit-resources-prbt-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-resources-prbt-support";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_resources_prbt_support/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "0c5506d615d401b0a52c242cad7288c373dc138a604c14cc9c83ae5393d7a165";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_resources_prbt_support/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "f840f9665db9cf5bd297b36c25f03f6c339a389620a854e9bd39de65f90a4f3f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-ros-benchmarks/default.nix
+++ b/distros/jazzy/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-ros-benchmarks";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_benchmarks/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "1afcfa53d1191596e80f3fa43096df04b1b8a3b41408d073663d2fdeab8971ec";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_benchmarks/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "64c3acca6a75ec96d3452a12342f1b8a666b7b3c4bd4b559e59ee5b21271fd9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-ros-control-interface/default.nix
+++ b/distros/jazzy/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager-msgs, moveit-common, moveit-core, moveit-simple-controller-manager, pluginlib, rclcpp-action, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-ros-control-interface";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_control_interface/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "eb2bcf0ff86d074365dd6b15de172a160b799fa257fa9ac5a207ed3fc7dae17b";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_control_interface/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "1388d16eb1bd36a5abb117d8c63b6dac73e7b5e09ed9af9707ddfe2cc42c71a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-ros-move-group/default.nix
+++ b/distros/jazzy/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, fmt, moveit-common, moveit-configs-utils, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, moveit-ros-planning, pluginlib, rclcpp, rclcpp-action, ros-testing, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-ros-move-group";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_move_group/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "99176001c215396765592e731fdbe65d8f2589fc15d7178c870e4695e986be19";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_move_group/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "c0e671dca07873b53660ac0110a060fa38acedb1286fd45da92ced2137c8d5b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/jazzy/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-ros-occupancy-map-monitor";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_occupancy_map_monitor/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "6e00771b076bd7d47e1765bef0000455db4f9adbaa413bf8aab0db409841acd5";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_occupancy_map_monitor/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "db277727aff31b97bb9b68fe18f0987af7d34bc5f294a61b9be25028ccb727e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-ros-perception/default.nix
+++ b/distros/jazzy/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, object-recognition-msgs, pluginlib, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-ros-perception";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_perception/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "07ee7ab9e5a83f50e4da268f39ba37acb1fbf3c282f95f0887a0d78c9e384438";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_perception/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "56cb98f6f6affc9948b4f9d7134aa80f0af64582aa1dc0adb82ac4f605a1dfbf";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-ros-planning-interface/default.nix
+++ b/distros/jazzy/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-ros-planning-interface";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_planning_interface/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "f31f03179242ad554eeb5f2f9b166c91e8f80c7a1975b0f53f1cd1191dbb31a6";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_planning_interface/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "bc6ca99446de8caefb9c9e3b50b877767a279ebdbd9a15b1f37dc61bf4b4bf65";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-ros-planning/default.nix
+++ b/distros/jazzy/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, eigen, eigen3-cmake-module, fmt, generate-parameter-library, launch-testing-ament-cmake, message-filters, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, rclcpp-components, ros-testing, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-ros-planning";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_planning/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "6357ba3028ed47fe01466d751ed149e555bf1a376de78f181d07b38d03d48ac9";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_planning/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "429e922d233029dc4bd108e7ee16ed50a035d73995bf3fd95e5d4588ce2d45f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-ros-robot-interaction/default.nix
+++ b/distros/jazzy/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, interactive-markers, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-ros-robot-interaction";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_robot_interaction/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "127a74e324c0002fb137a1016692e326ab57cd6f62f4508481e75a2e6e74423b";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_robot_interaction/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "6f7bae479b3ffea3729104544fed517d0b57b6374e50c3b4ead5ee00be443705";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-ros-tests/default.nix
+++ b/distros/jazzy/moveit-ros-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, moveit-common, moveit-configs-utils, moveit-core, moveit-planners-chomp, moveit-planners-ompl, moveit-planners-stomp, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-simple-controller-manager, pilz-industrial-motion-planner, rclcpp, ros-testing, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-ros-tests";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_tests/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "544cc356b75617bb721e17e396b9537b3ed9e787c1f6168d74704ff833448aa2";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_tests/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "526e81bd7a6a071792469a15d86b8f5718a78a0fd71c5579d3c1fdbe3a1ca166";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-ros-trajectory-cache/default.nix
+++ b/distros/jazzy/moveit-ros-trajectory-cache/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-uncrustify, geometry-msgs, launch-pytest, launch-testing-ament-cmake, moveit-common, moveit-configs-utils, moveit-planners-ompl, moveit-resources, moveit-ros, moveit-ros-planning-interface, python3Packages, rclcpp, rclcpp-action, rmf-utils, robot-state-publisher, ros2-control, tf2-ros, trajectory-msgs, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-ros-trajectory-cache";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_trajectory_cache/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "950a29150c8507d9e024316985e1b4483298ebdd5516bd77807002f5f620802d";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_trajectory_cache/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "654920beaaef6152322b3c78774546f5f21ccbae46fc76aa43ee16aa9e5ca749";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-ros-visualization/default.nix
+++ b/distros/jazzy/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, class-loader, eigen, geometric-shapes, interactive-markers, moveit-common, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, pkg-config, pluginlib, qt5, rclcpp, rclpy, rviz2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-ros-visualization";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_visualization/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "336e765bb20af30a9b08dbc764c5d4dcb051f646d40e6f96972f33e91180b0a4";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_visualization/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "e5ab5a84621e3828d247d6c34a91fa8d8930f087e5d57a64e341ec4d46023ae5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-ros-warehouse/default.nix
+++ b/distros/jazzy/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fmt, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-ros-warehouse";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_warehouse/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "7202bc84224fb5c20afabdff988a0a42dc3a271f4f0e03fc87e8b61a808ee10a";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_warehouse/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "f1093738c901a93f22313f8b770fbd8641dacdca408612441933b6e2483e39b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-ros/default.nix
+++ b/distros/jazzy/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-ros";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "6fb17e16065198509611fa88eb9671194ab79ec596d777429549e9fc80f2fcc9";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "ada9906025923b26ac994a98c9dc8f7a80d9afaf7c82e00100d85b0ab4724841";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-runtime/default.nix
+++ b/distros/jazzy/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-core, moveit-planners, moveit-plugins, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-runtime";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_runtime/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "1ccb0a570aca9b79c92d414f63048c1585068c5cc6e00c36e3a3360b3a519416";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_runtime/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "4946238083a068dc54610ca58627ba9d29055eb235a7ab64d247b73e4d473a11";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-servo/default.nix
+++ b/distros/jazzy/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, control-msgs, controller-manager, generate-parameter-library, geometry-msgs, gripper-controllers, joint-state-broadcaster, joint-trajectory-controller, joy, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-visualization, pluginlib, realtime-tools, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-servo";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_servo/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "4d69d929b07b1cea94f2c6fe8e95263730e5af0bbdd0271468b9b6ac223e0445";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_servo/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "c22e3d175692e6fbc1bff35d73efdb0799a641bc51930eaeb8982bbefa162f56";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-setup-app-plugins/default.nix
+++ b/distros/jazzy/moveit-setup-app-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, moveit-configs-utils, moveit-ros-visualization, moveit-setup-framework, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-setup-app-plugins";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_setup_app_plugins/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "02e413d6769710d915a88d9b3693dda6e59717b8f256e86758bdc2ba442fdf87";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_setup_app_plugins/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "df6241c1218ee5958906352a3ee67da3fd42c58ae81bf65dd09575d5262eab55";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-setup-assistant/default.nix
+++ b/distros/jazzy/moveit-setup-assistant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, moveit-configs-utils, moveit-resources-panda-moveit-config, moveit-setup-app-plugins, moveit-setup-controllers, moveit-setup-core-plugins, moveit-setup-framework, moveit-setup-srdf-plugins, pluginlib, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-setup-assistant";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_setup_assistant/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "cbc957b1e5bdbd6f66f742331712cd0b43b7c25cab638b0938ee8fdddd4ad597";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_setup_assistant/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "bb8774f7237754dc445b946cd8a379c80dd56bec47df7675d014ff082fb2eaaa";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-setup-controllers/default.nix
+++ b/distros/jazzy/moveit-setup-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, moveit-configs-utils, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-setup-framework, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-setup-controllers";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_setup_controllers/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "246e280204e5d5f02630e4f3997ba1c4c19f4f7d1ca8b3e904ec20b8e26d33ce";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_setup_controllers/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "28ab56d265946446f3366fcee4983b348b787ccf846d17683e37d9fe29b60828";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-setup-core-plugins/default.nix
+++ b/distros/jazzy/moveit-setup-core-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, moveit-ros-visualization, moveit-setup-framework, pluginlib, rclcpp, srdfdom, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-setup-core-plugins";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_setup_core_plugins/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "dd23ed79ba0c4d2bab1ad3bba5c8d62382dd7d0c467ea42ea0baf0ebaa9d2060";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_setup_core_plugins/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "c80826500ea25326c8ad15eead5ebc1b092e8d59473ef01d247b54e80ba774ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-setup-framework/default.nix
+++ b/distros/jazzy/moveit-setup-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, fmt, moveit-common, moveit-core, moveit-ros-planning, moveit-ros-visualization, pluginlib, rclcpp, rviz-common, rviz-rendering, srdfdom, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-setup-framework";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_setup_framework/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "f7112e62783bc5ed8613cd400bbf97023f4f4af4144cfbdac1bfaff48a47d267";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_setup_framework/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "fcebcc61f1ade142ae2b8bed833f8ca00c08c135cb64efd093ecceb53f05f3c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-setup-srdf-plugins/default.nix
+++ b/distros/jazzy/moveit-setup-srdf-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, moveit-resources-fanuc-description, moveit-setup-framework, pluginlib }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-setup-srdf-plugins";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_setup_srdf_plugins/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "c81ed9b55306edfcf7c89a8406f873a676cbe968ae9c700f53a3a98361687713";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_setup_srdf_plugins/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "26077da941286a8486a0239498faa52f427972c47cb5a4aa8d249e12d0508132";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-simple-controller-manager/default.nix
+++ b/distros/jazzy/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, control-msgs, moveit-common, moveit-core, pluginlib, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-simple-controller-manager";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_simple_controller_manager/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "590037083306075ddc33eee1ed23a82f2e74adbceb919f9f5af39c30255ef5bb";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_simple_controller_manager/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "bfe1a08b530af09c202e83e3bbcc52d7babee991880454de252977e2ad4cdb4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit/default.nix
+++ b/distros/jazzy/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-core, moveit-planners, moveit-plugins, moveit-ros, moveit-setup-assistant }:
 buildRosPackage {
   pname = "ros-jazzy-moveit";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "139a46b87065d7102e9092c2639e87af3e7cec39c5e9a9fb8ed063523481492e";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "7294fa1bef7b4d1b2911da5bd8f74a5d5386d46ef8890e9b62e4a675b4334440";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mp2p-icp/default.nix
+++ b/distros/jazzy/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, mola-common, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, ros-environment, tbb_2021_11 }:
 buildRosPackage {
   pname = "ros-jazzy-mp2p-icp";
-  version = "1.6.5-r1";
+  version = "1.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/jazzy/mp2p_icp/1.6.5-1.tar.gz";
-    name = "1.6.5-1.tar.gz";
-    sha256 = "739e798f83f41b6dd4186dd712a6674e10454e27fd27b47fdee444c20b695601";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/jazzy/mp2p_icp/1.6.6-1.tar.gz";
+    name = "1.6.6-1.tar.gz";
+    sha256 = "4970463f7c44e12138d2cb23481ae72efcb7fca0cbd1828456468aff6e450563";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/novatel-oem7-driver/default.nix
+++ b/distros/jazzy/novatel-oem7-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, geographiclib, git, gps-msgs, launch-testing, launch-testing-ament-cmake, launch-testing-ros, nav-msgs, nmea-msgs, novatel-oem7-msgs, pluginlib, rclcpp, rclcpp-components, rclpy, rosbag2, rosidl-runtime-py, sensor-msgs, tf2-geometry-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-novatel-oem7-driver";
+  version = "24.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/jazzy/novatel_oem7_driver/24.0.0-1.tar.gz";
+    name = "24.0.0-1.tar.gz";
+    sha256 = "188d01ed1555897506a96ee0b1b1ca9a4f40750a47acb37e0a04e30459626e83";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake git ];
+  checkInputs = [ launch-testing launch-testing-ament-cmake launch-testing-ros rclpy rosbag2 rosidl-runtime-py ];
+  propagatedBuildInputs = [ boost geographiclib gps-msgs nav-msgs nmea-msgs novatel-oem7-msgs pluginlib rclcpp rclcpp-components sensor-msgs tf2-geometry-msgs ];
+  nativeBuildInputs = [ ament-cmake git ];
+
+  meta = {
+    description = "NovAtel Oem7 ROS Driver";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/novatel-oem7-msgs/default.nix
+++ b/distros/jazzy/novatel-oem7-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-novatel-oem7-msgs";
+  version = "24.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/jazzy/novatel_oem7_msgs/24.0.0-1.tar.gz";
+    name = "24.0.0-1.tar.gz";
+    sha256 = "3e66b68d38d52a01c9e8a910f26c654f9618ee1b9437bac6d76e1965b4295428";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "Messages for NovAtel Oem7 family of receivers.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -48,8 +48,8 @@ in {
   };
 
   gz-common-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-common-vendor {
-    version = "5.7.0";
-    hash = "sha256-RBu49rxjzo4mc7ma4WpabUxUT7cvabJRinR98it10r4=";
+    version = "5.7.1";
+    hash = "sha256-vNCjCSQYCSUHXKwXnq8vwWXiSK2+cD3yPSLT1FdAWrE=";
   }).overrideAttrs ({
     nativeBuildInputs ? [], ...
   }: {

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -92,8 +92,8 @@ in {
   };
 
   gz-msgs-vendor = lib.patchGzAmentVendorGit rosSuper.gz-msgs-vendor {
-    version = "10.3.1";
-    hash = "sha256-GBEylFQvR2MWOIivW2+MGy//jjewId41mk8qpLfoaYM=";
+    version = "10.3.2";
+    hash = "sha256-gxhRqLzBCaDmK67T5RryDpxbDR3WLgV9DFs7w6ieMxQ=";
   };
 
   gz-ogre-next-vendor = (lib.patchAmentVendorGit rosSuper.gz-ogre-next-vendor {

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -42,36 +42,20 @@ in {
     fetchgitArgs.hash = "sha256-gztnxui9Fe/FTieMjdvfJjWHjkImtlsHn6fM1FruyME=";
   };
 
-  gz-cmake-vendor = lib.patchGzAmentVendorGit rosSuper.gz-cmake-vendor {
-    version = "3.5.4";
-    hash = "sha256-mP0bBPWWAoUFsUwKn95Eqv1lW3lJdPEu3hhfmiK3mNQ=";
-  };
+  gz-cmake-vendor = lib.patchGzAmentVendorGit rosSuper.gz-cmake-vendor { };
 
-  gz-common-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-common-vendor {
-    version = "5.7.1";
-    hash = "sha256-vNCjCSQYCSUHXKwXnq8vwWXiSK2+cD3yPSLT1FdAWrE=";
-  }).overrideAttrs ({
+  gz-common-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-common-vendor { }).overrideAttrs ({
     nativeBuildInputs ? [], ...
   }: {
     # https://github.com/gazebo-release/gz_common_vendor/pull/2
     nativeBuildInputs = nativeBuildInputs ++ [ self.pkg-config ];
   });
 
-  gz-dartsim-vendor = lib.patchAmentVendorGit rosSuper.gz-dartsim-vendor {
-    url = "https://github.com/dartsim/dart.git";
-    rev = "v6.13.2";
-    fetchgitArgs.hash = "sha256-AfKPqUiW6BsM98TIzTY2ZcFP1WvURs8/dGOzanIiB9g=";
-  };
+  gz-dartsim-vendor = lib.patchAmentVendorGit rosSuper.gz-dartsim-vendor { };
 
-  gz-fuel-tools-vendor = lib.patchGzAmentVendorGit rosSuper.gz-fuel-tools-vendor {
-    version = "9.1.0";
-    hash = "sha256-txeIzj2vmvL5NDu6O07c7LwcCWE26OFEzvyc9TBrJAw=";
-  };
+  gz-fuel-tools-vendor = lib.patchGzAmentVendorGit rosSuper.gz-fuel-tools-vendor { };
 
-  gz-gui-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-gui-vendor {
-    version = "8.3.0";
-    hash = "sha256-V0zaL6qrd510hMECCr3/mMkyqf4yu2aaKLRZ6Rw0s/4=";
-  }).overrideAttrs ({
+  gz-gui-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-gui-vendor { }).overrideAttrs ({
     postInstall ? "", ...
   }: {
     # "RPATH of binary libGrid3D.so contains a forbidden reference to
@@ -81,58 +65,27 @@ in {
     '';
   });
 
-  gz-launch-vendor = lib.patchGzAmentVendorGit rosSuper.gz-launch-vendor {
-    version = "7.1.0";
-    hash = "sha256-En3V8i/Ie8+KnSHGlm9Bap7REdLhYBaVHVbOM+/Pzno=";
-  };
+  gz-launch-vendor = lib.patchGzAmentVendorGit rosSuper.gz-launch-vendor { };
 
-  gz-math-vendor = lib.patchGzAmentVendorGit rosSuper.gz-math-vendor {
-    version = "7.5.2";
-    hash = "sha256-LwYeyv8nwX06n5ju+ra2uqNMedMSLRumem8qDHXtNns=";
-  };
+  gz-math-vendor = lib.patchGzAmentVendorGit rosSuper.gz-math-vendor { };
 
-  gz-msgs-vendor = lib.patchGzAmentVendorGit rosSuper.gz-msgs-vendor {
-    version = "10.3.2";
-    hash = "sha256-gxhRqLzBCaDmK67T5RryDpxbDR3WLgV9DFs7w6ieMxQ=";
-  };
+  gz-msgs-vendor = lib.patchGzAmentVendorGit rosSuper.gz-msgs-vendor { };
 
-  gz-ogre-next-vendor = (lib.patchAmentVendorGit rosSuper.gz-ogre-next-vendor {
-    url = "https://github.com/OGRECave/ogre-next.git";
-    rev = "v2.3.3";
-    fetchgitArgs.hash = "sha256-elSj35LwsLzj1ssDPsk9NW/KSXfiOGYmw9hQSAWdpFM=";
-  }).overrideAttrs({ ... }: {
+  gz-ogre-next-vendor = (lib.patchAmentVendorGit rosSuper.gz-ogre-next-vendor { }).overrideAttrs({ ... }: {
     dontFixCmake = true;
   });
 
-  gz-physics-vendor = lib.patchGzAmentVendorGit rosSuper.gz-physics-vendor {
-    version = "7.4.0";
-    hash = "sha256-14/P/xoZSqqqf9krgqDKVcO/rTZOEhLni8ZUR3W9ey4=";
-  };
+  gz-physics-vendor = lib.patchGzAmentVendorGit rosSuper.gz-physics-vendor { };
 
-  gz-plugin-vendor = lib.patchGzAmentVendorGit rosSuper.gz-plugin-vendor {
-    version = "2.0.4";
-    hash = "sha256-iL4+EdFFAU55FVqE/CvyTv1zNaXxBWqWx44L0BeG2MU=";
-  };
+  gz-plugin-vendor = lib.patchGzAmentVendorGit rosSuper.gz-plugin-vendor { };
 
-  gz-rendering-vendor = lib.patchGzAmentVendorGit rosSuper.gz-rendering-vendor {
-    version = "8.2.1";
-    hash = "sha256-ZHeEC/zvBKROJ/e+6Bdvhut30crhlC5VMsxrpIGIA0M=";
-  };
+  gz-rendering-vendor = lib.patchGzAmentVendorGit rosSuper.gz-rendering-vendor { };
 
-  gz-sensors-vendor = lib.patchGzAmentVendorGit rosSuper.gz-sensors-vendor {
-    version = "8.2.1";
-    hash = "sha256-wEUJoHbvvImuFbaKk84maw5AoKhoEhdU0uOYVBtHhI0=";
-  };
+  gz-sensors-vendor = lib.patchGzAmentVendorGit rosSuper.gz-sensors-vendor { };
 
-  gz-sim-vendor = lib.patchGzAmentVendorGit rosSuper.gz-sim-vendor {
-    version = "8.7.0";
-    hash = "sha256-Kalt+UwFiL1D+A5pkM/aZyEmBenqPo9U4jlAmqLze3c=";
-  };
+  gz-sim-vendor = lib.patchGzAmentVendorGit rosSuper.gz-sim-vendor { };
 
-  gz-tools-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-tools-vendor {
-    version = "2.0.2";
-    hash = "sha256-CY+W1jWIkszKwKuLgKmJpZMXHn0RnueMHFSDhOXIzLg=";
-  }).overrideAttrs({
+  gz-tools-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-tools-vendor { }).overrideAttrs({
     nativeBuildInputs ? [],
     propagatedNativeBuildInputs ? [],
     qtWrapperArgs ? [],
@@ -154,19 +107,13 @@ in {
     '';
   });
 
-  gz-transport-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-transport-vendor {
-    version = "13.4.1";
-    hash = "sha256-hCP+yVoyl1c3KNmQ5jKrYvPT1IlAy9JkCh0c0mOF+KM=";
-  }).overrideAttrs({
+  gz-transport-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-transport-vendor { }).overrideAttrs({
     buildInputs ? [], ...
   }: {
     buildInputs = buildInputs ++ [ self.libsodium ];
   });
 
-  gz-utils-vendor = lib.patchGzAmentVendorGit rosSuper.gz-utils-vendor {
-    version = "2.2.1";
-    hash = "sha256-utVW8pTP/emEWblTxVb6jzulKdxss+2VfS552MWMqm4=";
-  };
+  gz-utils-vendor = lib.patchGzAmentVendorGit rosSuper.gz-utils-vendor { };
 
   iceoryx-hoofs = rosSuper.iceoryx-hoofs.overrideAttrs ({
     patches ? [], ...
@@ -222,9 +169,6 @@ in {
   });
 
   rviz-ogre-vendor = lib.patchAmentVendorGit rosSuper.rviz-ogre-vendor {
-    url = "https://github.com/OGRECave/ogre.git";
-    rev = "v1.12.10";
-    fetchgitArgs.hash = "sha256-Z0ixdSmkV93coBBVZ5R3lPLfVMXRfWsFz/RsSyqPWFY=";
     tarSourceArgs.hook = let
       version = "1.79";
       imgui = self.fetchFromGitHub rec {
@@ -255,10 +199,7 @@ in {
     sha256 = "sha256-TyFt3d78GidhDGD17KgjAaZl/qvAcGJP8lmu4EOxpYg=";
   };
 
-  sdformat-vendor = lib.patchGzAmentVendorGit rosSuper.sdformat-vendor {
-    version = "14.7.0";
-    hash = "sha256-p2e01bCoMpDhia1yOFa5wIP2ritBiWNT5jYbp/bg1+g=";
-  };
+  sdformat-vendor = lib.patchGzAmentVendorGit rosSuper.sdformat-vendor { };
 
   urdfdom = rosSuper.urdfdom.overrideAttrs ({
     patches ? [], ...

--- a/distros/jazzy/pilz-industrial-motion-planner-testutils/default.nix
+++ b/distros/jazzy/pilz-industrial-motion-planner-testutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen3-cmake-module, moveit-common, moveit-core, moveit-msgs, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-jazzy-pilz-industrial-motion-planner-testutils";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/pilz_industrial_motion_planner_testutils/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "746152c01330056355966a4506ef0a49b72f95103971704a9b4cd94673bb0452";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/pilz_industrial_motion_planner_testutils/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "6676cd79e2004fd582dae55eb411b67e19e07e4f3935cddeaecba55356aaaa28";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pilz-industrial-motion-planner/default.nix
+++ b/distros/jazzy/pilz-industrial-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, boost, eigen3-cmake-module, generate-parameter-library, geometry-msgs, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-prbt-moveit-config, moveit-resources-prbt-pg70-support, moveit-resources-prbt-support, moveit-ros-move-group, moveit-ros-planning, orocos-kdl-vendor, pilz-industrial-motion-planner-testutils, pluginlib, rclcpp, ros-testing, tf2, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-pilz-industrial-motion-planner";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/pilz_industrial_motion_planner/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "c4252ab60d488e1b4f929b7010d9db7d2b2d547853d96015ff47d31ae0bea507";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/pilz_industrial_motion_planner/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "fa13e7c609ef1b5c15c2a2225b908ce2de538620010bbd8c34793bc38fb698f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pinocchio/default.nix
+++ b/distros/jazzy/pinocchio/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python3, python3Packages, urdfdom }:
+{ lib, buildRosPackage, fetchurl, boost, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python3, python3Packages, ros-environment, urdfdom }:
 buildRosPackage {
   pname = "ros-jazzy-pinocchio";
-  version = "2.6.21-r3";
+  version = "3.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/jazzy/pinocchio/2.6.21-3.tar.gz";
-    name = "2.6.21-3.tar.gz";
-    sha256 = "1f3a88fbd0b82eb3d5102a265b56d7a7c2fe4cd15629637c65e7aa5a8e64bd94";
+    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/jazzy/pinocchio/3.4.0-2.tar.gz";
+    name = "3.4.0-2.tar.gz";
+    sha256 = "e4b44521bb7be9015f9df2049a25e9759c644758b3a751be2d0d33ec8adb2b64";
   };
 
   buildType = "cmake";
   buildInputs = [ clang cmake doxygen git ];
-  propagatedBuildInputs = [ boost eigen eigenpy hpp-fcl python3 python3Packages.numpy urdfdom ];
+  propagatedBuildInputs = [ boost eigen eigenpy hpp-fcl python3 python3Packages.numpy ros-environment urdfdom ];
   nativeBuildInputs = [ clang cmake ];
 
   meta = {

--- a/distros/jazzy/realtime-tools/default.nix
+++ b/distros/jazzy/realtime-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, boost, libcap, lifecycle-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-realtime-tools";
-  version = "3.3.0-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/jazzy/realtime_tools/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "28f52f42a80f060c51577b71371c17eab1c9edd098adcd41af387e3f90dda962";
+    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/jazzy/realtime_tools/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "ca810261195c529bcdb17775fae3feb39dd5ad1f22dfded51adf2c8bfcb1be2b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rmw-zenoh-cpp/default.nix
+++ b/distros/jazzy/rmw-zenoh-cpp/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, fastcdr, rcpputils, rcutils, rmw, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, zenoh-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, fastcdr, rcpputils, rcutils, rmw, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, tracetools, zenoh-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-rmw-zenoh-cpp";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/jazzy/rmw_zenoh_cpp/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "f8aad3517113cc3023850df0c3ef1cde04021a909dbb0fc5c8966843675cae2e";
+    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/jazzy/rmw_zenoh_cpp/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "af0c94cc556bb9d01ff65cc8d786a2169dfebb90fefbde26e69b5a80882e86fc";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-cpp fastcdr rcpputils rcutils rmw rosidl-typesupport-fastrtps-c rosidl-typesupport-fastrtps-cpp zenoh-cpp-vendor ];
+  propagatedBuildInputs = [ ament-index-cpp fastcdr rcpputils rcutils rmw rosidl-typesupport-fastrtps-c rosidl-typesupport-fastrtps-cpp tracetools zenoh-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/rosapi-msgs/default.nix
+++ b/distros/jazzy/rosapi-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-rosapi-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosapi_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "b6c3ed4a465f98c0950cad840eb9cefbb614cb92a52a89c36e6e60889a6232a4";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosapi_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "a2ef75d06c7dbf62f361f71a6e9dd14a8e87983147b519d3242cb0461767e4e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosapi/default.nix
+++ b/distros/jazzy/rosapi/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2node, ros2param, ros2pkg, ros2service, ros2topic, rosapi-msgs, rosbridge-library, sensor-msgs, shape-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-mypy, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2node, ros2service, ros2topic, rosapi-msgs, rosbridge-library, sensor-msgs, shape-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rosapi";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosapi/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "4c97ead7a072adbe1c28061151fa593af621e19610716b7b38760e46951c46a5";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosapi/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "52c9e1ba46b70ca3052ef92b5b8f5270fce48dedd72595fd70a1934eb4d8adb0";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
-  checkInputs = [ ament-cmake-pytest geometry-msgs rmw-dds-common sensor-msgs shape-msgs ];
-  propagatedBuildInputs = [ builtin-interfaces rcl-interfaces rclpy ros2node ros2param ros2pkg ros2service ros2topic rosapi-msgs rosbridge-library ];
+  checkInputs = [ ament-cmake-mypy ament-cmake-pytest geometry-msgs rmw-dds-common sensor-msgs shape-msgs ];
+  propagatedBuildInputs = [ builtin-interfaces rcl-interfaces rclpy ros2node ros2service ros2topic rosapi-msgs rosbridge-library ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/jazzy/rosbridge-library/default.nix
+++ b/distros/jazzy/rosbridge-library/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, control-msgs, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rclpy, rosbridge-test-msgs, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-mypy, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, control-msgs, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rclpy, rosbridge-test-msgs, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rosbridge-library";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_library/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "480c31fcb705efec657fd65eaade555126a862d1030c94e88461c6faa8c7f51b";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_library/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "dd8e64b301a29e0a8a20d83ac5c3684d8d063e3d6e55512affcaf694f0bf298a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-ros ];
-  checkInputs = [ action-msgs ament-cmake-pytest builtin-interfaces control-msgs diagnostic-msgs example-interfaces geometry-msgs nav-msgs rosbridge-test-msgs sensor-msgs std-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
+  checkInputs = [ action-msgs ament-cmake-mypy ament-cmake-pytest builtin-interfaces control-msgs diagnostic-msgs example-interfaces geometry-msgs nav-msgs rosbridge-test-msgs sensor-msgs std-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
   propagatedBuildInputs = [ python3Packages.bson python3Packages.pillow rclpy rosidl-default-runtime ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 

--- a/distros/jazzy/rosbridge-msgs/default.nix
+++ b/distros/jazzy/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-rosbridge-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "0e898807bcc4b73d7a7d02e477c282441517166ffe424825e7406ba101c87e9a";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "ffae87a79ca0d64c242db71185761a7374a82b9bad8f201add3a7046285259a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbridge-server/default.nix
+++ b/distros/jazzy/rosbridge-server/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-mypy, ament-cmake-ros, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-rosbridge-server";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_server/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "c38ae48fdd47570d1dfa403b7e737dbac5d95e1664889a293003248abe0545d4";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_server/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "793f3cec42224a4a8ffd260c5ddb7ef260a87049cb00f3f03d4d9a2b15d84aac";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-ros ];
-  checkInputs = [ example-interfaces launch launch-ros launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.autobahn std-srvs ];
+  checkInputs = [ ament-cmake-mypy example-interfaces launch launch-ros launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.autobahn std-srvs ];
   propagatedBuildInputs = [ python3Packages.tornado python3Packages.twisted rclpy rosapi rosbridge-library rosbridge-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 

--- a/distros/jazzy/rosbridge-suite/default.nix
+++ b/distros/jazzy/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-jazzy-rosbridge-suite";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_suite/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "45edc8921c5dc6ca4479e4f61b9ec4d855af820a4e95ffb82290c07ebd9ade91";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_suite/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "f5fd423ac6f646221586b6c7082fe3d698488d70c8648c7ca1a958cc2292e77f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbridge-test-msgs/default.nix
+++ b/distros/jazzy/rosbridge-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rosbridge-test-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_test_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "6dd7e7c24d596b4bc0df3e20ef5ec1ae505f55a8e5329d6a2eee3bd09a7dbd55";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_test_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "46e83ee3a91142d4d22871ff40c630dedbe16e228f54f1ab1af3c5d397a9c9ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-ogre-vendor/vendored-source.json
+++ b/distros/jazzy/rviz-ogre-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/OGRECave/ogre.git",
+  "rev": "v1.12.10",
+  "hash": "sha256-Z0ixdSmkV93coBBVZ5R3lPLfVMXRfWsFz/RsSyqPWFY="
+}

--- a/distros/jazzy/sdformat-vendor/vendored-source.json
+++ b/distros/jazzy/sdformat-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/sdformat.git",
+  "rev": "sdformat14_14.7.0",
+  "hash": "sha256-p2e01bCoMpDhia1yOFa5wIP2ritBiWNT5jYbp/bg1+g="
+}

--- a/distros/jazzy/septentrio-gnss-driver/default.nix
+++ b/distros/jazzy/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-septentrio-gnss-driver";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/jazzy/septentrio_gnss_driver/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "79d191f5e2fbb5ac76ce9f4e2bcb2d25c8c0a58979c9d6bebc52c4934e885bfb";
+    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/jazzy/septentrio_gnss_driver/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "8cec94a2bcd6439dda03aa5bd5caa10869a657dc0431a626088f747aa759f10b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/simple-launch/default.nix
+++ b/distros/jazzy/simple-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-index-python, launch, launch-ros, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-simple-launch";
-  version = "1.10.1-r1";
+  version = "1.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/jazzy/simple_launch/1.10.1-1.tar.gz";
-    name = "1.10.1-1.tar.gz";
-    sha256 = "749bcc5bd434ae454981638f2e99ff8146f895d0a01842f03b8c2f2920741472";
+    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/jazzy/simple_launch/1.11.0-1.tar.gz";
+    name = "1.11.0-1.tar.gz";
+    sha256 = "fbe469ba422bb1feab53500bf9e2e5091cf605e0ec904489c2d5e6b2c3c9a679";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/synapticon-ros2-control/default.nix
+++ b/distros/jazzy/synapticon-ros2-control/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, forward-command-controller, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, libcap, pluginlib, rclcpp, rclcpp-lifecycle, robot-state-publisher, ros2controlcli, ros2launch, xacro }:
+buildRosPackage {
+  pname = "ros-jazzy-synapticon-ros2-control";
+  version = "0.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/synapticon/synapticon_ros2_control-release/archive/release/jazzy/synapticon_ros2_control/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "a0974b6db1912fd7a2d2290cc7b24655a3e44e6ac17282cb977ba544aec69e25";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ controller-manager forward-command-controller hardware-interface joint-state-broadcaster joint-trajectory-controller libcap pluginlib rclcpp rclcpp-lifecycle robot-state-publisher ros2controlcli ros2launch xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A ros2_control interface for Synapticon motor drivers";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/topic-tools-interfaces/default.nix
+++ b/distros/jazzy/topic-tools-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-topic-tools-interfaces";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/jazzy/topic_tools_interfaces/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "47688a1f8042523925b72d54a2a222550fda3a0ac86b1ee5fd8bc18c4c38c50f";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/jazzy/topic_tools_interfaces/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "9a123f2a8f13f7e0512bbe0930f06a5eba56c61aa2916c6870d0b3ea13ed2a3c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/topic-tools/default.nix
+++ b/distros/jazzy/topic-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclpy, ros2cli, rosidl-default-generators, rosidl-runtime-py, std-msgs, topic-tools-interfaces }:
 buildRosPackage {
   pname = "ros-jazzy-topic-tools";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/jazzy/topic_tools/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "37412def2a1c8c8270940066bd5f71bc242579fd2fbad80fffef0ced23bc40a0";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/jazzy/topic_tools/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "9b2616f1093bfd2e0965f7783b95ecf90d09f4b2de8635bcbeea83a1b88d1cc8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/turtlebot3-msgs/default.nix
+++ b/distros/jazzy/turtlebot3-msgs/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-turtlebot3-msgs";
-  version = "2.2.1-r5";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot3_msgs-release/archive/release/jazzy/turtlebot3_msgs/2.2.1-5.tar.gz";
-    name = "2.2.1-5.tar.gz";
-    sha256 = "55f9d98593aebddd637a78ef1355b40bfab2280058b33f3d9a17c9f2bd52cdf9";
+    url = "https://github.com/ros2-gbp/turtlebot3_msgs-release/archive/release/jazzy/turtlebot3_msgs/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "063b241526090d95e50d2946fbbca3cdbc71b1121af7abfbe8998ddeef160d20";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-lint-common ];
-  propagatedBuildInputs = [ action-msgs builtin-interfaces rosidl-default-runtime std-msgs ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {
-    description = "Message and service types: custom messages and services for TurtleBot3 packages for ROS2";
+    description = "Message and service types: custom messages and services for TurtleBot3 packages for ROS 2";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/jazzy/ur-client-library/default.nix
+++ b/distros/jazzy/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-jazzy-ur-client-library";
-  version = "1.6.0-r1";
+  version = "1.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/jazzy/ur_client_library/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "b1895c725fe2d0b2935b3cceeecc7e914e5ea0857994903681092452629bb771";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/jazzy/ur_client_library/1.7.1-1.tar.gz";
+    name = "1.7.1-1.tar.gz";
+    sha256 = "c80594dcf5f8a9eac439e1614e7273d1d000c3583f8f9a366bdabe0dd88d2d31";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/webots-ros2-control/default.nix
+++ b/distros/jazzy/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-control";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_control/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "8c0b409198f0dea7343366a3d5f83c465c50db4012f419fc54b25a8a6b71d4ac";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_control/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "7bf2f9dad0c1fd34ae443f2c3f3fec390a50d8d6b250373e0bece08f46bdf90c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/webots-ros2-crazyflie/default.nix
+++ b/distros/jazzy/webots-ros2-crazyflie/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, rclpy, tf-transformations, webots-ros2-driver }:
+buildRosPackage {
+  pname = "ros-jazzy-webots-ros2-crazyflie";
+  version = "2025.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_crazyflie/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "55ef94c9953ba6c5bf9f882fa6314405e987fd7e61a813f6e143196dc97b6bef";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
+  propagatedBuildInputs = [ builtin-interfaces rclpy tf-transformations webots-ros2-driver ];
+
+  meta = {
+    description = "ROS2 package for Crazyflie webots simulator";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/webots-ros2-driver/default.nix
+++ b/distros/jazzy/webots-ros2-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-driver";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_driver/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "caa552be3ee3632007ad4dfd618ffd103cff0c77c23705345d596de341f413de";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_driver/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "e054a133078cf7dc781ffc2f6752c6bc1c166894d21cb2d0a9fbf2029b9acd10";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/webots-ros2-epuck/default.nix
+++ b/distros/jazzy/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, python3Packages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-epuck";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_epuck/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "9fbed94264a2d0d3097d9e128a7800743cd130972a7f0943bcaebdf4b6f709e6";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_epuck/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "02f0d1f6ad01924af12db0503152b99d6742bfe616789b01b4c354856541fcc8";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/webots-ros2-husarion/default.nix
+++ b/distros/jazzy/webots-ros2-husarion/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, controller-manager, diff-drive-controller, joint-state-broadcaster, laser-filters, robot-localization, robot-state-publisher, webots-ros2-control, webots-ros2-driver }:
+buildRosPackage {
+  pname = "ros-jazzy-webots-ros2-husarion";
+  version = "2025.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_husarion/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "d70f3ce6f114f33eb9c34e6e69888b5dfee71cf445c84577243da7eaf416a8a3";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ controller-manager diff-drive-controller joint-state-broadcaster laser-filters robot-localization robot-state-publisher webots-ros2-control webots-ros2-driver ];
+
+  meta = {
+    description = "Husarion ROSbot 2R and XL robots ROS2 interface for Webots.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/webots-ros2-importer/default.nix
+++ b/distros/jazzy/webots-ros2-importer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-importer";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_importer/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "281f7c67d686666ef1618117e84f76f3a1f83b83d4a3ac70a76c8ee612d5685d";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_importer/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "95813d375f4aa3d96f57aeabe476303f6bbc2f73cbdb9851c6b812c4f8eb9725";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/webots-ros2-mavic/default.nix
+++ b/distros/jazzy/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-mavic";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_mavic/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "678521c76060f410adbb36d98ec1697b8167c1e78f9f812aad89643ef72f441d";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_mavic/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "9d31d53721298480efa74cfcf69df25d5bdf5cae45e99b48319e180695db20b4";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/webots-ros2-msgs/default.nix
+++ b/distros/jazzy/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-msgs";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_msgs/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "b2d69b0547187be071c6c85c9d83d085357641d95e89e5929cb78503c0a3aa85";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_msgs/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "b230a7967e8de47223f9821e41685324e36246e502a75f227afa1190bdaf1afe";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/webots-ros2-tesla/default.nix
+++ b/distros/jazzy/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, builtin-interfaces, python3Packages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-tesla";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_tesla/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "e77fa29d2e63ae1abce82e24f713f971c1902bb7301795f1e4cc55ac62212652";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_tesla/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "a89827398620dc30805af70929903f2fcaa37bfbd290f4d1ad3b234c1a89a6a7";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/webots-ros2-tests/default.nix
+++ b/distros/jazzy/webots-ros2-tests/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-husarion, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-tests";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_tests/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "d9f002f838ca43e25144d94c21da50dd3d286041aa885a28a87330eb6401e309";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_tests/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "2c340b556715c74a5f67835d0a8865acbdd6ce484b6eb00905bae5fc0ca6d3db";
   };
 
   buildType = "ament_python";
   buildInputs = [ rclpy ros2bag rosbag2-storage-default-plugins webots-ros2-driver ];
-  checkInputs = [ ament-copyright geometry-msgs launch launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.pytest sensor-msgs std-msgs std-srvs tf2-ros webots-ros2-epuck webots-ros2-mavic webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
+  checkInputs = [ ament-copyright geometry-msgs launch launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.pytest sensor-msgs std-msgs std-srvs tf2-ros webots-ros2-epuck webots-ros2-husarion webots-ros2-mavic webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
 
   meta = {
     description = "System tests for `webots_ros2` packages.";

--- a/distros/jazzy/webots-ros2-tiago/default.nix
+++ b/distros/jazzy/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, python3Packages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-tiago";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_tiago/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "490a79154c59e4ebdd581a0190c86cc381d921f9979f656238adaaf2338c5cb2";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_tiago/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "9ca09b49c702c10f48d20464b9c041f1672efaebfe54cc002c4f4b19d7d81305";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/webots-ros2-turtlebot/default.nix
+++ b/distros/jazzy/webots-ros2-turtlebot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, python3Packages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-turtlebot";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_turtlebot/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "02690b6c535a32c41fbaebb4219cb15e8d12afb6479ecdec4befc630ad9f2514";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_turtlebot/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "12b19e4c8303cabcee5c93d781740d80daaf7649817425138bf4f63f9813ec5b";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/webots-ros2-universal-robot/default.nix
+++ b/distros/jazzy/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, python3Packages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-universal-robot";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_universal_robot/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "6c2a39e82afdfa890dddb0dad395803146fdb8ba0332690b683bc5921fc07c04";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_universal_robot/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "6cd5ac9deb9f72f2611027d257274049fe12ce8798ee263d877e803e9965d287";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/webots-ros2/default.nix
+++ b/distros/jazzy/webots-ros2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, rclpy, std-msgs, webots-ros2-control, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, rclpy, std-msgs, webots-ros2-control, webots-ros2-crazyflie, webots-ros2-driver, webots-ros2-epuck, webots-ros2-husarion, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "6ae6ca8b3698e453c8485de2cec26853d2a0158e6edc939575b902c7b2558af4";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "c00d1f89a6d2e27abd946bc5b52c8e0b7ae6723f68ff4d43102f893dd856e743";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright python3Packages.pytest webots-ros2-tests ];
-  propagatedBuildInputs = [ builtin-interfaces rclpy std-msgs webots-ros2-control webots-ros2-driver webots-ros2-epuck webots-ros2-importer webots-ros2-mavic webots-ros2-msgs webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
+  propagatedBuildInputs = [ builtin-interfaces rclpy std-msgs webots-ros2-control webots-ros2-crazyflie webots-ros2-driver webots-ros2-epuck webots-ros2-husarion webots-ros2-importer webots-ros2-mavic webots-ros2-msgs webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
 
   meta = {
     description = "Interface between Webots and ROS2";

--- a/distros/jazzy/zenoh-cpp-vendor/default.nix
+++ b/distros/jazzy/zenoh-cpp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, cargo, clang, git }:
 buildRosPackage {
   pname = "ros-jazzy-zenoh-cpp-vendor";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/jazzy/zenoh_cpp_vendor/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "feaf03310f007e38a76f25cebb24cfa91124b5ff347286814012febefa39e249";
+    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/jazzy/zenoh_cpp_vendor/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "1e826d47fb9ab055ec58c23c411e3158cc5a0dd6fdbb6580c00ae1843f7a0ef5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-cmake-vendor/vendored-source.json
+++ b/distros/rolling/gz-cmake-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-cmake.git",
+  "rev": "gz-cmake4_4.1.0",
+  "hash": "sha256-GyVDbJM3qdFSdp+Kw8z1vB6ipOkB0+4TYWLV+FhIsj4="
+}

--- a/distros/rolling/gz-common-vendor/vendored-source.json
+++ b/distros/rolling/gz-common-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-common.git",
+  "rev": "gz-common6_6.0.1",
+  "hash": "sha256-gVyqzyvdGxXKRm0mpiR1nIYvceWwUDMmp85bHTEpZOE="
+}

--- a/distros/rolling/gz-dartsim-vendor/vendored-source.json
+++ b/distros/rolling/gz-dartsim-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/dartsim/dart.git",
+  "rev": "v6.13.2",
+  "hash": "sha256-AfKPqUiW6BsM98TIzTY2ZcFP1WvURs8/dGOzanIiB9g="
+}

--- a/distros/rolling/gz-fuel-tools-vendor/vendored-source.json
+++ b/distros/rolling/gz-fuel-tools-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-fuel-tools.git",
+  "rev": "gz-fuel-tools10_10.0.0",
+  "hash": "sha256-9WskZnci7D09aW32lzmdtlhRBM+hcmhG6iNgf3OC1js="
+}

--- a/distros/rolling/gz-gui-vendor/vendored-source.json
+++ b/distros/rolling/gz-gui-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-gui.git",
+  "rev": "gz-gui9_9.0.0",
+  "hash": "sha256-/YJW6XmdGwbyd5Nx3wcTqnRlpwE1unVGaNX91qfZmiM="
+}

--- a/distros/rolling/gz-math-vendor/vendored-source.json
+++ b/distros/rolling/gz-math-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-math.git",
+  "rev": "gz-math8_8.1.1",
+  "hash": "sha256-E7u3EtpqNLvcqI5ycezwwAlbVHM3JdqeyLFWYlEaOYo="
+}

--- a/distros/rolling/gz-math-vendor/vendored-source.json
+++ b/distros/rolling/gz-math-vendor/vendored-source.json
@@ -1,5 +1,5 @@
 {
   "url": "https://github.com/gazebosim/gz-math.git",
-  "rev": "gz-math8_8.1.1",
-  "hash": "sha256-E7u3EtpqNLvcqI5ycezwwAlbVHM3JdqeyLFWYlEaOYo="
+  "rev": "gz-math8_8.1.0",
+  "hash": "sha256-3jQk98HJ0ru2Q4fTqoiaPRaIHaWQKQlnqj+gN2PLxkE="
 }

--- a/distros/rolling/gz-msgs-vendor/vendored-source.json
+++ b/distros/rolling/gz-msgs-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-msgs.git",
+  "rev": "gz-msgs11_11.0.2",
+  "hash": "sha256-PUhFOmVPRiOVWfOjAU8z8dcxKPdcoTrgRwDGXP/vsUs="
+}

--- a/distros/rolling/gz-ogre-next-vendor/vendored-source.json
+++ b/distros/rolling/gz-ogre-next-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/OGRECave/ogre-next.git",
+  "rev": "v2.3.3",
+  "hash": "sha256-elSj35LwsLzj1ssDPsk9NW/KSXfiOGYmw9hQSAWdpFM="
+}

--- a/distros/rolling/gz-physics-vendor/vendored-source.json
+++ b/distros/rolling/gz-physics-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-physics.git",
+  "rev": "gz-physics8_8.0.0",
+  "hash": "sha256-PjwrJG3xvRYrkHDTaBUgoaW8NglEYDPuJrk4QjJjTHU="
+}

--- a/distros/rolling/gz-plugin-vendor/vendored-source.json
+++ b/distros/rolling/gz-plugin-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-plugin.git",
+  "rev": "gz-plugin3_3.0.1",
+  "hash": "sha256-7v6fzylJ4R1uoyQFM+eyl2/bXVy5MGC5dPjS7/taB8U="
+}

--- a/distros/rolling/gz-plugin-vendor/vendored-source.json
+++ b/distros/rolling/gz-plugin-vendor/vendored-source.json
@@ -1,5 +1,5 @@
 {
   "url": "https://github.com/gazebosim/gz-plugin.git",
-  "rev": "gz-plugin3_3.0.1",
-  "hash": "sha256-7v6fzylJ4R1uoyQFM+eyl2/bXVy5MGC5dPjS7/taB8U="
+  "rev": "gz-plugin3_3.0.0",
+  "hash": "sha256-h2Dx0KcFmJlS67q0v1zbd9nQkTCKgHkxt5KKTT5v+fw="
 }

--- a/distros/rolling/gz-rendering-vendor/vendored-source.json
+++ b/distros/rolling/gz-rendering-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-rendering.git",
+  "rev": "gz-rendering9_9.1.0",
+  "hash": "sha256-L2xkd93zhXtvbbzRrdjsoxbDtopp/RpcWBh1tfGvLeM="
+}

--- a/distros/rolling/gz-sensors-vendor/vendored-source.json
+++ b/distros/rolling/gz-sensors-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-sensors.git",
+  "rev": "gz-sensors9_9.0.0",
+  "hash": "sha256-8Ato7/YRL7JebbVPASD6VF9lf/Uyq26MIg2l+jQ4GDk="
+}

--- a/distros/rolling/gz-tools-vendor/vendored-source.json
+++ b/distros/rolling/gz-tools-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-tools.git",
+  "rev": "gz-tools2_2.0.2",
+  "hash": "sha256-CY+W1jWIkszKwKuLgKmJpZMXHn0RnueMHFSDhOXIzLg="
+}

--- a/distros/rolling/gz-transport-vendor/vendored-source.json
+++ b/distros/rolling/gz-transport-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-transport.git",
+  "rev": "gz-transport14_14.0.1",
+  "hash": "sha256-pSoadkpVaAEswmZuK13Y7PhxgvzTK1G2wI5+Fomlm/o="
+}

--- a/distros/rolling/gz-transport-vendor/vendored-source.json
+++ b/distros/rolling/gz-transport-vendor/vendored-source.json
@@ -1,5 +1,5 @@
 {
   "url": "https://github.com/gazebosim/gz-transport.git",
-  "rev": "gz-transport14_14.0.1",
-  "hash": "sha256-pSoadkpVaAEswmZuK13Y7PhxgvzTK1G2wI5+Fomlm/o="
+  "rev": "gz-transport14_14.0.0",
+  "hash": "sha256-zoGphy2cpmqJsnyS1LNVm4eGtHCWkAwIblga4RdVj4k="
 }

--- a/distros/rolling/gz-utils-vendor/vendored-source.json
+++ b/distros/rolling/gz-utils-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-utils.git",
+  "rev": "gz-utils3_3.1.0",
+  "hash": "sha256-pbbFO/4h3Tos+uigPC8XHWzv+Yuyd6EdzLWQPdmXaN8="
+}

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -42,36 +42,20 @@ in {
     fetchgitArgs.hash = "sha256-gztnxui9Fe/FTieMjdvfJjWHjkImtlsHn6fM1FruyME=";
   };
 
-  gz-cmake-vendor = lib.patchGzAmentVendorGit rosSuper.gz-cmake-vendor {
-    version = "4.1.0";
-    hash = "sha256-GyVDbJM3qdFSdp+Kw8z1vB6ipOkB0+4TYWLV+FhIsj4=";
-  };
+  gz-cmake-vendor = lib.patchGzAmentVendorGit rosSuper.gz-cmake-vendor { };
 
-  gz-common-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-common-vendor {
-    version = "6.0.0";
-    hash = "sha256-Oo4dGN2vsVaElKf/KYjjJq6tlYLRPr0/uh6urGxvDdc=";
-  }).overrideAttrs ({
+  gz-common-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-common-vendor { }).overrideAttrs ({
     nativeBuildInputs ? [], ...
   }: {
     # https://github.com/gazebo-release/gz_common_vendor/pull/2
     nativeBuildInputs = nativeBuildInputs ++ [ self.pkg-config ];
   });
 
-  gz-dartsim-vendor = lib.patchAmentVendorGit rosSuper.gz-dartsim-vendor {
-    url = "https://github.com/dartsim/dart.git";
-    rev = "v6.13.2";
-    fetchgitArgs.hash = "sha256-AfKPqUiW6BsM98TIzTY2ZcFP1WvURs8/dGOzanIiB9g=";
-  };
+  gz-dartsim-vendor = lib.patchAmentVendorGit rosSuper.gz-dartsim-vendor { };
 
-  gz-fuel-tools-vendor = lib.patchGzAmentVendorGit rosSuper.gz-fuel-tools-vendor {
-    version = "10.0.0";
-    hash = "sha256-9WskZnci7D09aW32lzmdtlhRBM+hcmhG6iNgf3OC1js=";
-  };
+  gz-fuel-tools-vendor = lib.patchGzAmentVendorGit rosSuper.gz-fuel-tools-vendor { };
 
-  gz-gui-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-gui-vendor {
-    version = "9.0.0";
-    hash = "sha256-/YJW6XmdGwbyd5Nx3wcTqnRlpwE1unVGaNX91qfZmiM=";
-  }).overrideAttrs ({
+  gz-gui-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-gui-vendor { }).overrideAttrs ({
     postInstall ? "", ...
   }: {
     # "RPATH of binary libGrid3D.so contains a forbidden reference to
@@ -81,58 +65,27 @@ in {
     '';
   });
 
-  gz-launch-vendor = lib.patchGzAmentVendorGit rosSuper.gz-launch-vendor {
-    version = "8.0.0";
-    hash = "sha256-K2W2SSlhJvF9mxEMNa7tZa3/3/LIvxZMGeVb0Mi6Vso=";
-  };
+  gz-launch-vendor = lib.patchGzAmentVendorGit rosSuper.gz-launch-vendor { };
 
-  gz-math-vendor = lib.patchGzAmentVendorGit rosSuper.gz-math-vendor {
-    version = "8.1.0";
-    hash = "sha256-3jQk98HJ0ru2Q4fTqoiaPRaIHaWQKQlnqj+gN2PLxkE=";
-  };
+  gz-math-vendor = lib.patchGzAmentVendorGit rosSuper.gz-math-vendor { };
 
-  gz-msgs-vendor = lib.patchGzAmentVendorGit rosSuper.gz-msgs-vendor {
-    version = "11.0.2";
-    hash = "sha256-PUhFOmVPRiOVWfOjAU8z8dcxKPdcoTrgRwDGXP/vsUs=";
-  };
+  gz-msgs-vendor = lib.patchGzAmentVendorGit rosSuper.gz-msgs-vendor { };
 
-  gz-ogre-next-vendor = (lib.patchAmentVendorGit rosSuper.gz-ogre-next-vendor {
-    url = "https://github.com/OGRECave/ogre-next.git";
-    rev = "v2.3.3";
-    fetchgitArgs.hash = "sha256-elSj35LwsLzj1ssDPsk9NW/KSXfiOGYmw9hQSAWdpFM=";
-  }).overrideAttrs({ ... }: {
+  gz-ogre-next-vendor = (lib.patchAmentVendorGit rosSuper.gz-ogre-next-vendor { }).overrideAttrs({ ... }: {
     dontFixCmake = true;
   });
 
-  gz-physics-vendor = lib.patchGzAmentVendorGit rosSuper.gz-physics-vendor {
-    version = "8.0.0";
-    hash = "sha256-PjwrJG3xvRYrkHDTaBUgoaW8NglEYDPuJrk4QjJjTHU=";
-  };
+  gz-physics-vendor = lib.patchGzAmentVendorGit rosSuper.gz-physics-vendor { };
 
-  gz-plugin-vendor = lib.patchGzAmentVendorGit rosSuper.gz-plugin-vendor {
-    version = "3.0.0";
-    hash = "sha256-h2Dx0KcFmJlS67q0v1zbd9nQkTCKgHkxt5KKTT5v+fw=";
-  };
+  gz-plugin-vendor = lib.patchGzAmentVendorGit rosSuper.gz-plugin-vendor { };
 
-  gz-rendering-vendor = lib.patchGzAmentVendorGit rosSuper.gz-rendering-vendor {
-    version = "9.0.0";
-    hash = "sha256-e3OPLeqV6OgjnQrbpwRj59e7Z0BqN2wOee/gAaMHfqU=";
-  };
+  gz-rendering-vendor = lib.patchGzAmentVendorGit rosSuper.gz-rendering-vendor { };
 
-  gz-sensors-vendor = lib.patchGzAmentVendorGit rosSuper.gz-sensors-vendor {
-    version = "9.0.0";
-    hash = "sha256-8Ato7/YRL7JebbVPASD6VF9lf/Uyq26MIg2l+jQ4GDk=";
-  };
+  gz-sensors-vendor = lib.patchGzAmentVendorGit rosSuper.gz-sensors-vendor { };
 
-  gz-sim-vendor = lib.patchGzAmentVendorGit rosSuper.gz-sim-vendor {
-    version = "9.0.0";
-    hash = "sha256-gsWKknqcTiJc4YHIkmg1YGItwHG1As2OUnpPBQIwqj8=";
-  };
+  gz-sim-vendor = lib.patchGzAmentVendorGit rosSuper.gz-sim-vendor { };
 
-  gz-tools-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-tools-vendor {
-    version = "2.0.2";
-    hash = "sha256-CY+W1jWIkszKwKuLgKmJpZMXHn0RnueMHFSDhOXIzLg=";
-  }).overrideAttrs({
+  gz-tools-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-tools-vendor { }).overrideAttrs({
     nativeBuildInputs ? [],
     propagatedNativeBuildInputs ? [],
     qtWrapperArgs ? [],
@@ -154,19 +107,13 @@ in {
     '';
   });
 
-  gz-transport-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-transport-vendor {
-    version = "14.0.0";
-    hash = "sha256-zoGphy2cpmqJsnyS1LNVm4eGtHCWkAwIblga4RdVj4k=";
-  }).overrideAttrs({
+  gz-transport-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-transport-vendor { }).overrideAttrs({
     buildInputs ? [], ...
   }: {
     buildInputs = buildInputs ++ [ self.libsodium ];
   });
 
-  gz-utils-vendor = lib.patchGzAmentVendorGit rosSuper.gz-utils-vendor {
-    version = "3.1.0";
-    hash = "sha256-pbbFO/4h3Tos+uigPC8XHWzv+Yuyd6EdzLWQPdmXaN8=";
-  };
+  gz-utils-vendor = lib.patchGzAmentVendorGit rosSuper.gz-utils-vendor { };
 
   iceoryx-hoofs = rosSuper.iceoryx-hoofs.overrideAttrs ({
     patches ? [], ...
@@ -229,9 +176,6 @@ in {
   };
 
   rviz-ogre-vendor = lib.patchAmentVendorGit rosSuper.rviz-ogre-vendor {
-    url = "https://github.com/OGRECave/ogre.git";
-    rev = "v1.12.10";
-    fetchgitArgs.hash = "sha256-Z0ixdSmkV93coBBVZ5R3lPLfVMXRfWsFz/RsSyqPWFY=";
     tarSourceArgs.hook = let
       version = "1.79";
       imgui = self.fetchFromGitHub rec {
@@ -257,10 +201,7 @@ in {
     '';
   });
 
-  sdformat-vendor = lib.patchGzAmentVendorGit rosSuper.sdformat-vendor {
-    version = "15.1.1";
-    hash = "sha256-4/0pVaev++v0+wHQiGeTl8XtTDzh2li32dND0EjfjwA=";
-  };
+  sdformat-vendor = lib.patchGzAmentVendorGit rosSuper.sdformat-vendor { };
 
   shared-queues-vendor = lib.patchVendorUrl rosSuper.shared-queues-vendor {
     url = "https://github.com/cameron314/readerwriterqueue/archive/ef7dfbf553288064347d51b8ac335f1ca489032a.zip";

--- a/distros/rolling/rviz-ogre-vendor/vendored-source.json
+++ b/distros/rolling/rviz-ogre-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/OGRECave/ogre.git",
+  "rev": "v1.12.10",
+  "hash": "sha256-Z0ixdSmkV93coBBVZ5R3lPLfVMXRfWsFz/RsSyqPWFY="
+}

--- a/distros/rolling/sdformat-vendor/vendored-source.json
+++ b/distros/rolling/sdformat-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/sdformat.git",
+  "rev": "sdformat15_15.2.0",
+  "hash": "sha256-RarpOKoJ9w+yJw5HU5exZYjx1zVdtkE05+8PBADhOwY="
+}

--- a/distros/rolling/sdformat-vendor/vendored-source.json
+++ b/distros/rolling/sdformat-vendor/vendored-source.json
@@ -1,5 +1,5 @@
 {
   "url": "https://github.com/gazebosim/sdformat.git",
-  "rev": "sdformat15_15.2.0",
-  "hash": "sha256-RarpOKoJ9w+yJw5HU5exZYjx1zVdtkE05+8PBADhOwY="
+  "rev": "sdformat15_15.1.1",
+  "hash": "sha256-4/0pVaev++v0+wHQiGeTl8XtTDzh2li32dND0EjfjwA="
 }

--- a/lib/ament_cmake_vendor_packageConfig.cmake
+++ b/lib/ament_cmake_vendor_packageConfig.cmake
@@ -1,0 +1,31 @@
+# CMake package that defines alternative version of ament_vendor macro
+# to extract information about vendored source to
+# vendored-source.json. Normally, the ament_vendor macro is defined in
+# the ament_cmake_vendor_package and it downloads the vendored source
+# code at compile time. This is not possible with Nix, because Nix
+# builds packages without network access. Therefore, we can inject
+# this alternative macro to cmake and it will extract the information
+# needed by Nix to download the source code itself. All of this is
+# implemented in patchAmentVendorGit function.
+
+if(NOT ament_cmake_vendor_package_FIND_QUIETLY)
+  message(STATUS "Found ament_cmake_vendor_package: Dummy version for Nix patching (${ament_cmake_vendor_package_DIR})")
+endif()
+
+find_program(JQ jq)
+find_program(NIX_PREFETCH_GIT nix-prefetch-git)
+
+macro(ament_vendor TARGET_NAME)
+  cmake_parse_arguments(_ARG "GLOBAL_HOOK;SKIP_INSTALL" "SOURCE_SUBDIR;VCS_TYPE;VCS_URL;VCS_VERSION;SATISFIED" "CMAKE_ARGS;PATCHES" ${ARGN})
+  if(_ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "ament_vendor() called with unused arguments: "
+      "${_ARG_UNPARSED_ARGUMENTS}")
+  endif()
+
+  execute_process(
+    COMMAND ${NIX_PREFETCH_GIT} --url ${_ARG_VCS_URL} --rev ${_ARG_VCS_VERSION}
+    COMMAND ${JQ} "{url: \"${_ARG_VCS_URL}\", rev: \"${_ARG_VCS_VERSION}\", hash: .hash}"
+    OUTPUT_FILE ${CMAKE_BINARY_DIR}/vendored-source.json
+    COMMAND_ECHO STDOUT
+    COMMAND_ERROR_IS_FATAL ANY)
+endmacro()

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -81,51 +81,77 @@
   # Patch a vendored download that uses ament_vendor() with a Git repo as the
   # source.
   patchAmentVendorGit = pkg: {
-    url,
-    originalUrl ? url,
-    rev, # Must correspond to the VCS_VERSION argument
     file ? "CMakeLists.txt",
     fetchgitArgs ? {},
     tarSourceArgs ? {}
   }: pkg.overrideAttrs ({
     nativeBuildInputs ? [],
+    passthru ? {},
     postPatch ? "", ...
   }: let
+    vendoredSourceJson = "${dirOf pkg.meta.position}/vendored-source.json";
+    inherit (builtins) stringLength substring pathExists;
+    nameStart = 5 + stringLength pkg.rosDistro; # e.g. ros-jazzy- => 10
+    attr = substring nameStart (-1) pkg.pname;
+    errMsg = ''
+      error: File ${vendoredSourceJson} missing.
+      Run "$(nix-build -A rosPackages.${pkg.rosDistro}.${attr}.updateAmentVendor)" to create it.
+    '';
+    sourceInfo = builtins.fromJSON (builtins.readFile vendoredSourceJson);
     # ament_vendor doesn't allow patches for path inputs, so we have to pack it
     # into a tar first. Additionally, vcstool only accepts tarballs with the
     # version number as the root directory name.
-    vendor = lib.tarSource tarSourceArgs (self.fetchgit (fetchgitArgs // {
-      name = rev;
-      inherit url rev;
-    }));
+    vendor = lib.tarSource tarSourceArgs (
+      self.fetchgit (sourceInfo // fetchgitArgs // {
+        name = sourceInfo.rev;
+      }));
   in {
     # CMake ExternalProject patches are applied with git apply
     nativeBuildInputs = nativeBuildInputs ++ [ self.git ];
-    postPatch = ''
-      sed -i '\|VCS_URL\s*${originalUrl}|c\
+    postPatch = (if pathExists vendoredSourceJson then ''
+      sed -i '\|VCS_URL\s*|c\
         VCS_URL "file://${vendor}"\
         VCS_TYPE tar' \
         ${lib.escapeShellArg file}
-    '' + postPatch;
+    '' else ''
+      echo >&2 ${lib.escapeShellArg errMsg}
+      exit 1
+    '') + postPatch;
+    passthru = passthru // {
+      updateAmentVendor = let
+        source = self.srcOnly pkg;
+        sourceDrvPath = builtins.unsafeDiscardOutputDependency source.drvPath;
+        amentVendorNix = self.runCommand "ament_cmake_vendor_package_nix" {} ''
+          install -D ${./ament_cmake_vendor_packageConfig.cmake} $out/ament_cmake_vendor_packageConfig.cmake
+        '';
+        updateScript = self.writeShellScript "ament-vendor-update.sh" ''
+          set -eo pipefail
+          cd "$(${self.coreutils}/bin/mktemp -d)"
+          trap "${self.coreutils}/bin/rm -rf '$PWD'" SIGINT SIGTERM ERR EXIT
+          source "$stdenv/setup"
+          export NIX_SSL_CERT_FILE="${self.cacert}/etc/ssl/certs/ca-bundle.crt"
+          # Inject our version of ament_cmake_vendor_package
+          export PATH="${lib.makeBinPath (with self; [ nix-prefetch-git jq ])}:$PATH"
+          export CMAKE_PREFIX_PATH=${amentVendorNix}
+          phases="''${prePhases[*]:-} unpackPhase patchPhase ''${preConfigurePhases[*]:-} configurePhase ''${preBuildPhases[*]:-}" \
+            genericBuild
+          # Copy the resulting data to package source directory
+          cp -v vendored-source.json ${dirOf pkg.meta.position}
+        '';
+      in self.writeShellScript "update-${pkg.pname}" ''
+        set -eo pipefail
+        NIX_BUILD_SHELL=${self.runtimeShell} nix-shell --pure ${sourceDrvPath} --run ${updateScript}
+      '';
+    };
   });
 
   # patchAmentVendorGit specialized for gz-*-vendor packages. In
-  # addition to patching ament_vendor() calls, it adds a check to
-  # CMakeLists.txt to detect upstream updates of the vendored package
-  # version.
+  # addition to patching ament_vendor() calls, it patches other things
+  # in CMakeLists.txt.
   patchGzAmentVendorGit = pkg: {
-    version,
-    hash,
     tarSourceArgs ? {}
   }: let
-    stem = lib.strings.removeSuffix "-vendor"
-      (lib.strings.removePrefix "ros-${pkg.rosDistro}-" pkg.pname); # e.g. gz-cmake
-    majorNum = lib.versions.major version;
     patchedPkg = lib.patchAmentVendorGit pkg {
-      url = "https://github.com/gazebosim/${stem}.git";
-      originalUrl = "https://github.com/gazebosim/\${GITHUB_NAME}.git";
-      rev = "${stem}${majorNum}_${version}"; # e.g. "gz-cmake3_3.5.3"
-      fetchgitArgs.hash = hash;
       inherit tarSourceArgs;
     };
   in patchedPkg.overrideAttrs ({
@@ -137,12 +163,6 @@
         --replace-fail 'opt/''${PROJECT_NAME}/extra_cmake' 'share/extra_cmake'
       substituteInPlace *-extras.cmake.in \
         --replace-fail 'opt/@PROJECT_NAME@/extra_cmake' 'share/extra_cmake'
-
-      cat >> CMakeLists.txt <<'EOF'
-      if(NOT ''${LIB_VER} VERSION_EQUAL "${version}")
-        message(FATAL_ERROR "Mismatch in ${pname} version (Nix: ${version}, upstream: ''${LIB_VER}). Fix this in overrides.nix.")
-      endif()
-      EOF
     '';
   });
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -140,6 +140,7 @@
         '';
       in self.writeShellScript "update-${pkg.pname}" ''
         set -eo pipefail
+        echo ============== Updating ${pkg.pname} ==============
         NIX_BUILD_SHELL=${self.runtimeShell} nix-shell --pure ${sourceDrvPath} --run ${updateScript}
       '';
     };

--- a/maintainers/scripts/update-ament-vendor.sh
+++ b/maintainers/scripts/update-ament-vendor.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash --pure
+#! nix-shell -p nix-eval-jobs jq nix findutils coreutils bash moreutils
+
+# Scrip to generate/update vendored-source.json files needed by
+# patchAmentVendorGit.
+#
+# Run it from the top-level directory of this repo, i.e.,
+# ./maintainers/scripts/update-ament-vendor.sh [ -1 ]
+#
+# If some vendored packages depend on others, this script needs to be
+# run multiple times to generate all files. For updating, just one run
+# is needed.
+
+if [[ $1 == "-1" ]]; then
+    MAX_PROCS=1                 # Execute serially
+else
+    MAX_PROCS=$(nproc)          # Execute in parallel (default)
+fi
+
+# Extract all rosPackages (ignoring eval errors)
+nix-eval-jobs --expr '(import ./. {}).rosPackages' |
+    # Select only packages that depend on ament-cmake-vendor-package
+    jq -r 'select(.inputDrvs|objects|keys|any(contains("ament-cmake-vendor-package"))).attr' |
+    # In serial execution, wait for the complete package list to be ready before continuing
+    if [[ $MAX_PROCS = 1 ]]; then sponge; else cat; fi |
+    # Try (re)generating all vendored-source.json files, warn (but not fail) about packages without updateAmentVendor
+    xargs --verbose --max-procs="$MAX_PROCS" -IATTR \
+          bash -xc '$(nix-build --expr "with import ./. {}; rosPackages.ATTR.updateAmentVendor or (writeShellScript \"update-error\" \"echo Warning: ATTR cannot be updated\")")'

--- a/maintainers/scripts/update-ament-vendor.sh
+++ b/maintainers/scripts/update-ament-vendor.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env nix-shell
 #! nix-shell -i bash --pure --keep NIX_PATH
-#! nix-shell -p nix-eval-jobs jq nix findutils coreutils bash moreutils cachix
+#! nix-shell -p nix-eval-jobs jq nix findutils rush-parallel bash moreutils
 
 # Scrip to generate/update vendored-source.json files needed by
 # patchAmentVendorGit.
@@ -12,20 +12,16 @@
 # run multiple times to generate all files. For updating, just one run
 # is needed.
 
-if [[ $1 == "-1" ]]; then
-    MAX_PROCS=1                 # Execute serially
-else
-    MAX_PROCS=$(nproc)          # Execute in parallel (default)
-fi
-
-# Extract all rosPackages (ignoring eval errors)
+# # Extract all rosPackages (ignoring eval errors)
 nix-eval-jobs --expr '(import ./. {}).rosPackages' |
     # Select only packages that depend on ament-cmake-vendor-package
     jq -r 'select(.inputDrvs|objects|keys|any(contains("ament-cmake-vendor-package"))).attr' |
-    # In serial execution, wait for the complete package list to be ready before continuing
-    if [[ $MAX_PROCS = 1 ]]; then sponge; else cat; fi |
-    # Try to (re)generate all vendored-source.json files. Warn (but
-    # not fail) about packages without updateAmentVendor and fail if
-    # updateAmentVendor fails.
-    xargs --verbose --max-procs="$MAX_PROCS" -n1 \
-          bash -c '$(nix-build --expr "with import ./. {}; rosPackages.$0.updateAmentVendor or (builtins.warn \"$0 cannot be updated\" (writeShellScript \"nop\" \"\"))"|tee -a to-upload)'
+    # Wait for the complete package list to not mix eval errors with build output
+    sponge |
+    # Generate the update scripts and warn (but not fail) about packages without updateAmentVendor.
+    rush --keep-order "nix-build --expr \
+         'with import ./. { }; rosPackages.{}.updateAmentVendor or (builtins.warn \"{} cannot be updated\" (writeShellScript \"nop\" \"\"))'" |
+    grep -v -e '-nop$' |
+    sponge |
+    # Try to (re)generate all vendored-source.json files
+    rush --keep-order --verbose "bash -c '{} 2>&1'"

--- a/maintainers/scripts/update-ament-vendor.sh
+++ b/maintainers/scripts/update-ament-vendor.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env nix-shell
 #! nix-shell -i bash --pure --keep NIX_PATH
-#! nix-shell -p nix-eval-jobs jq nix findutils coreutils bash moreutils
+#! nix-shell -p nix-eval-jobs jq nix findutils coreutils bash moreutils cachix
 
 # Scrip to generate/update vendored-source.json files needed by
 # patchAmentVendorGit.
@@ -28,4 +28,4 @@ nix-eval-jobs --expr '(import ./. {}).rosPackages' |
     # not fail) about packages without updateAmentVendor and fail if
     # updateAmentVendor fails.
     xargs --verbose --max-procs="$MAX_PROCS" -n1 \
-          bash -c '$(nix-build --expr "with import ./. {}; rosPackages.$0.updateAmentVendor or (builtins.warn \"$0 cannot be updated\" (writeShellScript \"nop\" \"\"))")'
+          bash -c '$(nix-build --expr "with import ./. {}; rosPackages.$0.updateAmentVendor or (builtins.warn \"$0 cannot be updated\" (writeShellScript \"nop\" \"\"))"|tee -a to-upload)'

--- a/maintainers/scripts/update-ament-vendor.sh
+++ b/maintainers/scripts/update-ament-vendor.sh
@@ -27,5 +27,5 @@ nix-eval-jobs --expr '(import ./. {}).rosPackages' |
     # Try to (re)generate all vendored-source.json files. Warn (but
     # not fail) about packages without updateAmentVendor and fail if
     # updateAmentVendor fails.
-    xargs --verbose --max-procs="$MAX_PROCS" \
+    xargs --verbose --max-procs="$MAX_PROCS" -n1 \
           bash -c '$(nix-build --expr "with import ./. {}; rosPackages.$0.updateAmentVendor or (builtins.warn \"$0 cannot be updated\" (writeShellScript \"nop\" \"\"))")'

--- a/maintainers/scripts/update-ament-vendor.sh
+++ b/maintainers/scripts/update-ament-vendor.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -i bash --pure
+#! nix-shell -i bash --pure --keep NIX_PATH
 #! nix-shell -p nix-eval-jobs jq nix findutils coreutils bash moreutils
 
 # Scrip to generate/update vendored-source.json files needed by

--- a/maintainers/scripts/update-ament-vendor.sh
+++ b/maintainers/scripts/update-ament-vendor.sh
@@ -26,4 +26,4 @@ nix-eval-jobs --expr '(import ./. {}).rosPackages' |
     if [[ $MAX_PROCS = 1 ]]; then sponge; else cat; fi |
     # Try (re)generating all vendored-source.json files, warn (but not fail) about packages without updateAmentVendor
     xargs --verbose --max-procs="$MAX_PROCS" -IATTR \
-          bash -xc '$(nix-build --expr "with import ./. {}; rosPackages.ATTR.updateAmentVendor or (writeShellScript \"update-error\" \"echo Warning: ATTR cannot be updated\")")'
+          bash -xc 'echo =================================; $(nix-build --expr "with import ./. {}; rosPackages.ATTR.updateAmentVendor or (writeShellScript \"update-error\" \"echo Warning: ATTR cannot be updated\")")'

--- a/pkgs/superflore/default.nix
+++ b/pkgs/superflore/default.nix
@@ -8,10 +8,11 @@ buildPythonPackage rec {
   version = "unstable-2024-03-22";
 
   src = fetchFromGitHub {
-    owner = "lopsided98";
-    repo = pname;
-    rev = "f3b2aceae47ced2d0a0af868cd4cce2b6de5effa";
-    hash = "sha256-YRgzRuMvG7AXHkTFO87GLBobaQArO6gxpacifDq1CPo=";
+    owner = "wentasah";
+    repo = "superflore";
+    rev = "21bf33dbf9eb0e3a703f60fb0a09751918e3aae6";
+    hash = "sha256-WkV+kquzrhCYLZuSwr2iNqVJMoyOTE1n+OKPChnmxQ0=";
+    # date = "2025-02-25T22:55:55+01:00";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['jazzy'] from nix-ros-overlay commit 2e1fec8e652eb2252977d9c01b9d6d8189fd3749.
This pull request was generated by running the following command:

```
superflore-gen-nix --dry-run --tar-archive-dir /home/runner/.ros/tar --output-repository-path . --upstream-branch develop --ros-distro jazzy
```

Jazzy Changes:
==============
* *apriltag 3.4.2-r1 --> 3.4.3-r1*
* *battery-state-broadcaster 1.0.1-r1 --> 1.0.0-r1*
* *battery-state-rviz-overlay 1.0.1-r1 --> 1.0.0-r1*
* *chomp-motion-planner 2.12.1-r1 --> 2.12.2-r1*
* *depthai-bridge 2.10.5-r1 --> 2.11.0-r1*
* *depthai-descriptions 2.10.5-r1 --> 2.11.0-r1*
* *depthai-examples 2.10.5-r1 --> 2.11.0-r1*
* *depthai-filters 2.10.5-r1 --> 2.11.0-r1*
* *depthai-ros 2.10.5-r1 --> 2.11.0-r1*
* *depthai-ros-driver 2.10.5-r1 --> 2.11.0-r1*
* *depthai-ros-msgs 2.10.5-r1 --> 2.11.0-r1*
* *ds-dbw 2.3.1-r1 --> 2.3.2-r1*
* *ds-dbw-can 2.3.1-r1 --> 2.3.2-r1*
* *ds-dbw-joystick-demo 2.3.1-r1 --> 2.3.2-r1*
* *ds-dbw-msgs 2.3.1-r1 --> 2.3.2-r1*
* *dynamixel-interfaces 1.0.0-r1*
* *dynamixel-workbench-msgs 2.0.3-r5 --> 2.1.0-r1*
* *etsi-its-cam-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cam-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cam-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cam-ts-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cam-ts-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cam-ts-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cpm-ts-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cpm-ts-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cpm-ts-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-denm-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-denm-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-denm-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-denm-ts-coding 3.1.0-r1*
* *etsi-its-denm-ts-conversion 3.1.0-r1*
* *etsi-its-denm-ts-msgs 3.1.0-r1*
* *etsi-its-mapem-ts-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-mapem-ts-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-mapem-ts-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-messages 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-msgs-utils 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-primitives-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-rviz-plugins 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-spatem-ts-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-spatem-ts-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-spatem-ts-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-vam-ts-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-vam-ts-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-vam-ts-msgs 3.0.0-r1 --> 3.1.0-r1*
* *gz-launch-vendor 0.0.4-r1 --> 0.0.5-r1*
* *gz-msgs-vendor 0.0.5-r1 --> 0.0.6-r1*
* *gz-ros2-control 1.2.10-r1 --> 1.2.11-r1*
* *gz-ros2-control-demos 1.2.10-r1 --> 1.2.11-r1*
* *gz-sim-vendor 0.0.7-r1 --> 0.0.8-r1*
* *hebi-cpp-api 3.12.3-r1*
* *hls-lfcd-lds-driver 2.0.4-r6 --> 2.1.0-r1*
* *kitti-metrics-eval 1.6.1-r1 --> 1.6.2-r1*
* *mola 1.6.1-r1 --> 1.6.2-r1*
* *mola-bridge-ros2 1.6.1-r1 --> 1.6.2-r1*
* *mola-demos 1.6.1-r1 --> 1.6.2-r1*
* *mola-gnss-to-markers 0.1.0-r1*
* *mola-imu-preintegration 1.6.1-r1 --> 1.7.0-r1*
* *mola-input-euroc-dataset 1.6.1-r1 --> 1.6.2-r1*
* *mola-input-kitti-dataset 1.6.1-r1 --> 1.6.2-r1*
* *mola-input-kitti360-dataset 1.6.1-r1 --> 1.6.2-r1*
* *mola-input-mulran-dataset 1.6.1-r1 --> 1.6.2-r1*
* *mola-input-paris-luco-dataset 1.6.1-r1 --> 1.6.2-r1*
* *mola-input-rawlog 1.6.1-r1 --> 1.6.2-r1*
* *mola-input-rosbag2 1.6.1-r1 --> 1.6.2-r1*
* *mola-kernel 1.6.1-r1 --> 1.6.2-r1*
* *mola-launcher 1.6.1-r1 --> 1.6.2-r1*
* *mola-lidar-odometry 0.6.1-r1 --> 0.7.0-r1*
* *mola-metric-maps 1.6.1-r1 --> 1.6.2-r1*
* *mola-msgs 1.6.1-r1 --> 1.6.2-r1*
* *mola-pose-list 1.6.1-r1 --> 1.6.2-r1*
* *mola-relocalization 1.6.1-r1 --> 1.6.2-r1*
* *mola-state-estimation 1.6.1-r1 --> 1.7.0-r1*
* *mola-state-estimation-simple 1.6.1-r1 --> 1.7.0-r1*
* *mola-state-estimation-smoother 1.6.1-r1 --> 1.7.0-r1*
* *mola-traj-tools 1.6.1-r1 --> 1.6.2-r1*
* *mola-viz 1.6.1-r1 --> 1.6.2-r1*
* *mola-yaml 1.6.1-r1 --> 1.6.2-r1*
* *moveit 2.12.1-r1 --> 2.12.2-r1*
* *moveit-common 2.12.1-r1 --> 2.12.2-r1*
* *moveit-configs-utils 2.12.1-r1 --> 2.12.2-r1*
* *moveit-core 2.12.1-r1 --> 2.12.2-r1*
* *moveit-hybrid-planning 2.12.1-r1 --> 2.12.2-r1*
* *moveit-kinematics 2.12.1-r1 --> 2.12.2-r1*
* *moveit-planners 2.12.1-r1 --> 2.12.2-r1*
* *moveit-planners-chomp 2.12.1-r1 --> 2.12.2-r1*
* *moveit-planners-ompl 2.12.1-r1 --> 2.12.2-r1*
* *moveit-planners-stomp 2.12.1-r1 --> 2.12.2-r1*
* *moveit-plugins 2.12.1-r1 --> 2.12.2-r1*
* *moveit-py 2.12.1-r1 --> 2.12.2-r1*
* *moveit-resources-prbt-ikfast-manipulator-plugin 2.12.1-r1 --> 2.12.2-r1*
* *moveit-resources-prbt-moveit-config 2.12.1-r1 --> 2.12.2-r1*
* *moveit-resources-prbt-pg70-support 2.12.1-r1 --> 2.12.2-r1*
* *moveit-resources-prbt-support 2.12.1-r1 --> 2.12.2-r1*
* *moveit-ros 2.12.1-r1 --> 2.12.2-r1*
* *moveit-ros-benchmarks 2.12.1-r1 --> 2.12.2-r1*
* *moveit-ros-control-interface 2.12.1-r1 --> 2.12.2-r1*
* *moveit-ros-move-group 2.12.1-r1 --> 2.12.2-r1*
* *moveit-ros-occupancy-map-monitor 2.12.1-r1 --> 2.12.2-r1*
* *moveit-ros-perception 2.12.1-r1 --> 2.12.2-r1*
* *moveit-ros-planning 2.12.1-r1 --> 2.12.2-r1*
* *moveit-ros-planning-interface 2.12.1-r1 --> 2.12.2-r1*
* *moveit-ros-robot-interaction 2.12.1-r1 --> 2.12.2-r1*
* *moveit-ros-tests 2.12.1-r1 --> 2.12.2-r1*
* *moveit-ros-trajectory-cache 2.12.1-r1 --> 2.12.2-r1*
* *moveit-ros-visualization 2.12.1-r1 --> 2.12.2-r1*
* *moveit-ros-warehouse 2.12.1-r1 --> 2.12.2-r1*
* *moveit-runtime 2.12.1-r1 --> 2.12.2-r1*
* *moveit-servo 2.12.1-r1 --> 2.12.2-r1*
* *moveit-setup-app-plugins 2.12.1-r1 --> 2.12.2-r1*
* *moveit-setup-assistant 2.12.1-r1 --> 2.12.2-r1*
* *moveit-setup-controllers 2.12.1-r1 --> 2.12.2-r1*
* *moveit-setup-core-plugins 2.12.1-r1 --> 2.12.2-r1*
* *moveit-setup-framework 2.12.1-r1 --> 2.12.2-r1*
* *moveit-setup-srdf-plugins 2.12.1-r1 --> 2.12.2-r1*
* *moveit-simple-controller-manager 2.12.1-r1 --> 2.12.2-r1*
* *mp2p-icp 1.6.5-r1 --> 1.6.6-r1*
* *novatel-oem7-driver 24.0.0-r1*
* *novatel-oem7-msgs 24.0.0-r1*
* *pilz-industrial-motion-planner 2.12.1-r1 --> 2.12.2-r1*
* *pilz-industrial-motion-planner-testutils 2.12.1-r1 --> 2.12.2-r1*
* *pinocchio 2.6.21-r3 --> 3.4.0-r2*
* *realtime-tools 3.3.0-r1 --> 3.4.0-r1*
* *rmw-zenoh-cpp 0.2.1-r1 --> 0.2.2-r1*
* *rosapi 2.1.0-r1 --> 2.2.0-r1*
* *rosapi-msgs 2.1.0-r1 --> 2.2.0-r1*
* *rosbridge-library 2.1.0-r1 --> 2.2.0-r1*
* *rosbridge-msgs 2.1.0-r1 --> 2.2.0-r1*
* *rosbridge-server 2.1.0-r1 --> 2.2.0-r1*
* *rosbridge-suite 2.1.0-r1 --> 2.2.0-r1*
* *rosbridge-test-msgs 2.1.0-r1 --> 2.2.0-r1*
* *septentrio-gnss-driver 1.4.1-r1 --> 1.4.2-r1*
* *simple-launch 1.10.1-r1 --> 1.11.0-r1*
* *synapticon-ros2-control 0.1.2-r1*
* *topic-tools 1.3.2-r1 --> 1.3.3-r1*
* *topic-tools-interfaces 1.3.2-r1 --> 1.3.3-r1*
* *turtlebot3-msgs 2.2.1-r5 --> 2.3.0-r1*
* *ur-client-library 1.6.0-r1 --> 1.7.1-r1*
* *webots-ros2 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-control 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-crazyflie 2025.0.0-r1*
* *webots-ros2-driver 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-epuck 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-husarion 2025.0.0-r1*
* *webots-ros2-importer 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-mavic 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-msgs 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-tesla 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-tests 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-tiago 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-turtlebot 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-universal-robot 2023.1.3-r1 --> 2025.0.0-r1*
* *zenoh-cpp-vendor 0.2.1-r1 --> 0.2.2-r1*


Missing Dependencies:
=====================
 * [ ] autoware_utils
 * [ ] gazebo_ros_pkgs
 * [ ] gurumdds-3.2
 * [ ] libserial-dev
 * [ ] python3-httpx
 * [ ] python3-platformdirs
 * [ ] python3-setproctitle
 * [ ] python3-wheel
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo
 * [ ] velodyne_description