### PR TITLE
rosdistro sync, Tue Mar  4 12:05:07 2025

### DIFF
--- a/distros/rolling/fastdds/default.nix
+++ b/distros/rolling/fastdds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, python3, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-rolling-fastdds";
-  version = "3.1.2-r1";
+  version = "3.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastdds-release/archive/release/rolling/fastdds/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "167c2dca35012b69b5124d1ddc1eeb5a3362899d7d78ba970af9380959a4ff34";
+    url = "https://github.com/ros2-gbp/fastdds-release/archive/release/rolling/fastdds/3.1.2-2.tar.gz";
+    name = "3.1.2-2.tar.gz";
+    sha256 = "8f46286dab603522faf269c68fe7ad11d2a2ff768feb3a816e548387ce603028";
   };
 
   buildType = "cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -1774,7 +1774,11 @@ self: super: {
 
  rmw-dds-common = self.callPackage ./rmw-dds-common {};
 
- rmw-desert = self.callPackage ./rmw-desert {};
+ rmw-fastrtps-cpp = self.callPackage ./rmw-fastrtps-cpp {};
+
+ rmw-fastrtps-dynamic-cpp = self.callPackage ./rmw-fastrtps-dynamic-cpp {};
+
+ rmw-fastrtps-shared-cpp = self.callPackage ./rmw-fastrtps-shared-cpp {};
 
  rmw-implementation = self.callPackage ./rmw-implementation {};
 

--- a/distros/rolling/gz-launch-vendor/vendored-source.json
+++ b/distros/rolling/gz-launch-vendor/vendored-source.json
@@ -1,5 +1,5 @@
 {
   "url": "https://github.com/gazebosim/gz-launch.git",
-  "rev": "gz-launch8_8.0.0",
-  "hash": "sha256-el+4sVBOmeBj8VJqKut8pIhVJeyEyodrt6titunbBBB="
+  "rev": "gz-launch8_8.0.1",
+  "hash": "sha256-el+4sVBOmeBj8VJqKut8pIhVJeyEyodrt6titunbBF0="
 }

--- a/distros/rolling/rmw-fastrtps-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-cpp/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-dynamic-typesupport, rosidl-dynamic-typesupport-fastrtps, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs, tracetools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastdds, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-dynamic-typesupport, rosidl-dynamic-typesupport-fastrtps, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-cpp";
-  version = "9.2.0-r1";
+  version = "9.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_cpp/9.2.0-1.tar.gz";
-    name = "9.2.0-1.tar.gz";
-    sha256 = "c5710ff4833523d1589eadd0df85e9dd5f86aca48592a60f8c8ad87cd7632d40";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_cpp/9.3.0-1.tar.gz";
+    name = "9.3.0-1.tar.gz";
+    sha256 = "30c0d52caa2043721c6f13b18a359dd2c14cd06590efc89f0d928b99a33e7c8e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common osrf-testing-tools-cpp test-msgs ];
-  propagatedBuildInputs = [ ament-cmake fastcdr fastrtps fastrtps-cmake-module rcpputils rcutils rmw rmw-dds-common rmw-fastrtps-shared-cpp rosidl-dynamic-typesupport rosidl-dynamic-typesupport-fastrtps rosidl-runtime-c rosidl-runtime-cpp rosidl-typesupport-fastrtps-c rosidl-typesupport-fastrtps-cpp tracetools ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-ros fastrtps-cmake-module ];
+  propagatedBuildInputs = [ ament-cmake fastcdr fastdds rcpputils rcutils rmw rmw-dds-common rmw-fastrtps-shared-cpp rosidl-dynamic-typesupport rosidl-dynamic-typesupport-fastrtps rosidl-runtime-c rosidl-runtime-cpp rosidl-typesupport-fastrtps-c rosidl-typesupport-fastrtps-cpp tracetools ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 
   meta = {
     description = "Implement the ROS middleware interface using eProsima FastRTPS static code generation in C++.";

--- a/distros/rolling/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-dynamic-cpp/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs, tracetools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastdds, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-dynamic-cpp";
-  version = "9.2.0-r1";
+  version = "9.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_dynamic_cpp/9.2.0-1.tar.gz";
-    name = "9.2.0-1.tar.gz";
-    sha256 = "c8cc95f32c9c460253eb4694dd7b04378ccf9d4af54d1d69c3167645f5b4b888";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_dynamic_cpp/9.3.0-1.tar.gz";
+    name = "9.3.0-1.tar.gz";
+    sha256 = "01fc3b864f3b68b2eb38146287e328713def70ba9be816e24ed7689ee9ad940b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common osrf-testing-tools-cpp test-msgs ];
-  propagatedBuildInputs = [ ament-cmake fastcdr fastrtps fastrtps-cmake-module rcpputils rcutils rmw rmw-dds-common rmw-fastrtps-shared-cpp rosidl-runtime-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp tracetools ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-ros fastrtps-cmake-module ];
+  propagatedBuildInputs = [ ament-cmake fastcdr fastdds rcpputils rcutils rmw rmw-dds-common rmw-fastrtps-shared-cpp rosidl-runtime-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp tracetools ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 
   meta = {
     description = "Implement the ROS middleware interface using introspection type support.";

--- a/distros/rolling/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-shared-cpp/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastdds, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-security-common, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-shared-cpp";
-  version = "9.2.0-r1";
+  version = "9.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_shared_cpp/9.2.0-1.tar.gz";
-    name = "9.2.0-1.tar.gz";
-    sha256 = "3decde6188505319b9ae51025390e9739c6238a45a17d0c7b11d485f00a133e6";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_shared_cpp/9.3.0-1.tar.gz";
+    name = "9.3.0-1.tar.gz";
+    sha256 = "ae852cf58bc20756740aa37d74e843fa34dedb41c9e8188b319860a2a8dec570";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros rosidl-runtime-c ];
   checkInputs = [ ament-lint-auto ament-lint-common osrf-testing-tools-cpp ];
-  propagatedBuildInputs = [ ament-cmake fastcdr fastrtps fastrtps-cmake-module rcpputils rcutils rmw rmw-dds-common rosidl-dynamic-typesupport rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp tracetools ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-ros fastrtps-cmake-module ];
+  propagatedBuildInputs = [ ament-cmake fastcdr fastdds rcpputils rcutils rmw rmw-dds-common rmw-security-common rosidl-dynamic-typesupport rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp tracetools ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 
   meta = {
     description = "Code shared on static and dynamic type support of rmw_fastrtps_cpp.";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'noetic', 'rolling'] from nix-ros-overlay commit 7e97da57debd674365f8276b9680b285f637beee.
This pull request was generated by running the following command:

```
superflore-gen-nix --dry-run --tar-archive-dir /home/runner/.ros/tar --output-repository-path . --upstream-branch ament-vendor-auto-update-test --all
```

Changes:
========
Rolling Changes:
----------------
* *fastdds 3.1.2-r1 --> 3.1.2-r2*
* *rmw-fastrtps-cpp 9.2.0-r1 --> 9.3.0-r1*
* *rmw-fastrtps-dynamic-cpp 9.2.0-r1 --> 9.3.0-r1*
* *rmw-fastrtps-shared-cpp 9.2.0-r1 --> 9.3.0-r1*


Missing Dependencies:
=====================
 * [ ] action_tutorials_interfaces
 * [ ] atlas
 * [ ] autoware_utils
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] fastrtps
 * [ ] festival
 * [ ] gazebo_ros2_control
 * [ ] gazebo_ros_pkgs
 * [ ] gurumdds-3.0
 * [ ] gurumdds-3.2
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-httpx
 * [ ] python3-icecream
 * [ ] python3-marisa
 * [ ] python3-platformdirs
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-pysnmp-mibs
 * [ ] python3-pytorch-pip
 * [ ] python3-rosdep
 * [ ] python3-setproctitle
 * [ ] python3-torch-geometric-pip
 * [ ] python3-wheel
 * [ ] qtbase5-private-dev
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] velodyne_description
 * [ ] warehouse_ros_mongo
 * [ ] wiimote