### PR TITLE
rosdistro sync, Fri Mar  7 16:57:46 2025

### DIFF
--- a/distros/humble/apriltag-detector-mit/default.nix
+++ b/distros/humble/apriltag-detector-mit/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, apriltag-detector, apriltag-mit, apriltag-msgs, cv-bridge, image-transport, pluginlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, apriltag-detector, apriltag-mit, apriltag-msgs, pluginlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-apriltag-detector-mit";
-  version = "2.1.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/humble/apriltag_detector_mit/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "427a93a5ea75d6cd13179c3afb0a3af1a8662c72a86a61bdd6ce5b6a01cc6a4e";
+    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/humble/apriltag_detector_mit/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "e5c5face20780e63e4ff77e33e9c604967ad71eb63bad5f911f19df5816fb181";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ros-environment ];
   checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ apriltag-detector apriltag-mit apriltag-msgs cv-bridge image-transport pluginlib rclcpp rclcpp-components sensor-msgs ];
+  propagatedBuildInputs = [ apriltag-detector apriltag-mit apriltag-msgs pluginlib rclcpp rclcpp-components sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ros-environment ];
 
   meta = {

--- a/distros/humble/apriltag-detector-umich/default.nix
+++ b/distros/humble/apriltag-detector-umich/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, apriltag, apriltag-detector, apriltag-msgs, cv-bridge, image-transport, pluginlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, apriltag, apriltag-detector, apriltag-msgs, opencv, pluginlib, rclcpp, ros-environment, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-apriltag-detector-umich";
-  version = "2.1.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/humble/apriltag_detector_umich/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "5b5ac74c952879d765ac592c4bc19094eba1ccc00bf30e9b168207d51caa198b";
+    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/humble/apriltag_detector_umich/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "4262aa6cfdf1bda923dde7b182c36a0bb49989f41a918715054003e4f6ad9c00";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ros-environment ];
   checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ apriltag apriltag-detector apriltag-msgs cv-bridge image-transport pluginlib rclcpp rclcpp-components sensor-msgs ];
+  propagatedBuildInputs = [ apriltag apriltag-detector apriltag-msgs opencv opencv.cxxdev pluginlib rclcpp sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ros-environment ];
 
   meta = {

--- a/distros/humble/apriltag-detector/default.nix
+++ b/distros/humble/apriltag-detector/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, apriltag-msgs, pluginlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, apriltag-msgs, cv-bridge, image-transport, pluginlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-apriltag-detector";
-  version = "2.1.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/humble/apriltag_detector/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "6e0eaba3a7cd79288dd0cad427150fca3ae3f1fe362499f449dea5f2db4124c1";
+    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/humble/apriltag_detector/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "7adddff38517f348ea468fee47e7f3e813617d2844ea476371074f253918300c";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ros-environment ];
+  buildInputs = [ ament-cmake ros-environment ];
   checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ apriltag-msgs pluginlib rclcpp rclcpp-components sensor-msgs ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ros-environment ];
+  propagatedBuildInputs = [ apriltag-msgs cv-bridge image-transport pluginlib rclcpp rclcpp-components sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ros-environment ];
 
   meta = {
     description = "ROS2 package for apriltag detection";

--- a/distros/humble/apriltag-draw/default.nix
+++ b/distros/humble/apriltag-draw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, apriltag-msgs, cv-bridge, image-transport, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-apriltag-draw";
-  version = "2.1.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/humble/apriltag_draw/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "b2b2b56ae64ef3919c30b47008171f24ca55f39a10fa3603428941ee53904a1c";
+    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/humble/apriltag_draw/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "1e6f0a3b5bd0d392ef39b5ca494da1192599c122e0b5b10b4792fcee48ecd52d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/apriltag-tools/default.nix
+++ b/distros/humble/apriltag-tools/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, apriltag-detector, apriltag-draw, apriltag-msgs, rclcpp, ros-environment, rosbag2-transport }:
+buildRosPackage {
+  pname = "ros-humble-apriltag-tools";
+  version = "3.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/humble/apriltag_tools/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "20718b08e15ed2969d62a62d697f2bad64f6c7ccc708b39488940dacc004546c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment ];
+  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ apriltag-detector apriltag-draw apriltag-msgs rclcpp rosbag2-transport ];
+  nativeBuildInputs = [ ament-cmake ros-environment ];
+
+  meta = {
+    description = "misc tools for working with apriltags under ROS2";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/camera-calibration/default.nix
+++ b/distros/humble/camera-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, cv-bridge, image-geometry, message-filters, python3Packages, rclpy, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-camera-calibration";
-  version = "3.0.6-r1";
+  version = "3.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/camera_calibration/3.0.6-1.tar.gz";
-    name = "3.0.6-1.tar.gz";
-    sha256 = "3ff8c98d75b09256c5f0f5e28790cb750a0bbf1f2d00065c889feef1bffd7289";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/camera_calibration/3.0.7-1.tar.gz";
+    name = "3.0.7-1.tar.gz";
+    sha256 = "d6a80965caddfc0467e66c19d6522d3bfb7edbdb60560852445285a291ff7781";
   };
 
   buildType = "ament_python";

--- a/distros/humble/clearpath-config/default.nix
+++ b/distros/humble/clearpath-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-clearpath-config";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "0adfe45870e64a8b8a31a96f30a6bb000db31eb95b806b81fa54c350722cd517";
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "de113ff30b9172a6f7cc7baf9bdc30bb3f6b60e6b6e0afde81c0b9c3af61cffc";
   };
 
   buildType = "ament_python";

--- a/distros/humble/depth-image-proc/default.nix
+++ b/distros/humble/depth-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, class-loader, cv-bridge, image-geometry, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, stereo-msgs, tf2, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-depth-image-proc";
-  version = "3.0.6-r1";
+  version = "3.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/depth_image_proc/3.0.6-1.tar.gz";
-    name = "3.0.6-1.tar.gz";
-    sha256 = "790403571393f77ae51f5dc1c56c4c0336f67a681f91008de4af533be575c1f9";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/depth_image_proc/3.0.7-1.tar.gz";
+    name = "3.0.7-1.tar.gz";
+    sha256 = "b55bbf25bbf9b5ac1fd4c9e518a9fdc83d35d5825a13fd8daaf105d71c9d2581";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -206,6 +206,8 @@ self: super: {
 
  apriltag-ros = self.callPackage ./apriltag-ros {};
 
+ apriltag-tools = self.callPackage ./apriltag-tools {};
+
  aruco = self.callPackage ./aruco {};
 
  aruco-msgs = self.callPackage ./aruco-msgs {};
@@ -1338,6 +1340,8 @@ self: super: {
 
  kinova-gen3-7dof-robotiq-2f-85-moveit-config = self.callPackage ./kinova-gen3-7dof-robotiq-2f-85-moveit-config {};
 
+ kinova-gen3-lite-moveit-config = self.callPackage ./kinova-gen3-lite-moveit-config {};
+
  kitti-metrics-eval = self.callPackage ./kitti-metrics-eval {};
 
  kobuki-core = self.callPackage ./kobuki-core {};
@@ -2248,6 +2252,8 @@ self: super: {
 
  pmb2-navigation = self.callPackage ./pmb2-navigation {};
 
+ pmb2-rgbd-sensors = self.callPackage ./pmb2-rgbd-sensors {};
+
  pmb2-robot = self.callPackage ./pmb2-robot {};
 
  pmb2-simulation = self.callPackage ./pmb2-simulation {};
@@ -2585,6 +2591,8 @@ self: super: {
  rmw-cyclonedds-cpp = self.callPackage ./rmw-cyclonedds-cpp {};
 
  rmw-dds-common = self.callPackage ./rmw-dds-common {};
+
+ rmw-desert = self.callPackage ./rmw-desert {};
 
  rmw-fastrtps-cpp = self.callPackage ./rmw-fastrtps-cpp {};
 
@@ -3243,6 +3251,8 @@ self: super: {
  tiago-moveit-config = self.callPackage ./tiago-moveit-config {};
 
  tiago-navigation = self.callPackage ./tiago-navigation {};
+
+ tiago-rgbd-sensors = self.callPackage ./tiago-rgbd-sensors {};
 
  tiago-robot = self.callPackage ./tiago-robot {};
 

--- a/distros/humble/image-pipeline/default.nix
+++ b/distros/humble/image-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, camera-calibration, depth-image-proc, image-proc, image-publisher, image-rotate, image-view, stereo-image-proc }:
 buildRosPackage {
   pname = "ros-humble-image-pipeline";
-  version = "3.0.6-r1";
+  version = "3.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/image_pipeline/3.0.6-1.tar.gz";
-    name = "3.0.6-1.tar.gz";
-    sha256 = "5ef1151d93c41b8845f72dd2b92b7ba90120b6d0bb6aea23166618b2f6a3cb54";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/image_pipeline/3.0.7-1.tar.gz";
+    name = "3.0.7-1.tar.gz";
+    sha256 = "85c981869b01dfd36017297b6626fec52dd0a8cfad55d9ce710d2fe56ffe653d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/image-proc/default.nix
+++ b/distros/humble/image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, cv-bridge, image-geometry, image-transport, opencv, rclcpp, rclcpp-components, rcutils, sensor-msgs, tracetools-image-pipeline }:
 buildRosPackage {
   pname = "ros-humble-image-proc";
-  version = "3.0.6-r1";
+  version = "3.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/image_proc/3.0.6-1.tar.gz";
-    name = "3.0.6-1.tar.gz";
-    sha256 = "9cf2ecfa7bca00fec55a209c9dd835435e4b0bb5d8af02b3f6f6578f0f8c59a6";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/image_proc/3.0.7-1.tar.gz";
+    name = "3.0.7-1.tar.gz";
+    sha256 = "d512d1522426597038a0c4e31546327d8c49dd2f47c1bedda803054449d0881a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/image-publisher/default.nix
+++ b/distros/humble/image-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, camera-info-manager, cv-bridge, image-transport, rcl-interfaces, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-humble-image-publisher";
-  version = "3.0.6-r1";
+  version = "3.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/image_publisher/3.0.6-1.tar.gz";
-    name = "3.0.6-1.tar.gz";
-    sha256 = "475a2ef901c6ce1de40b5526c0f3cee2de88e61c46608b4d78152667633094a5";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/image_publisher/3.0.7-1.tar.gz";
+    name = "3.0.7-1.tar.gz";
+    sha256 = "589cb341082c8f19f5e430d4fdd1192511e888a9115c440820b9ff08c72ea692";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/image-rotate/default.nix
+++ b/distros/humble/image-rotate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, class-loader, cv-bridge, geometry-msgs, image-transport, opencv, rcl-interfaces, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-image-rotate";
-  version = "3.0.6-r1";
+  version = "3.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/image_rotate/3.0.6-1.tar.gz";
-    name = "3.0.6-1.tar.gz";
-    sha256 = "af54c0bdc07a9c77f7ded770623fcecf19e1a57ae04d83b008f4708c561a6965";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/image_rotate/3.0.7-1.tar.gz";
+    name = "3.0.7-1.tar.gz";
+    sha256 = "b31ad45c16e2b143f1bf1d18a085da141356d0da5f7eacda107bd0faed59374f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/image-view/default.nix
+++ b/distros/humble/image-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, boost, camera-calibration-parsers, cv-bridge, image-transport, message-filters, rclcpp, rclcpp-components, sensor-msgs, std-srvs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-humble-image-view";
-  version = "3.0.6-r1";
+  version = "3.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/image_view/3.0.6-1.tar.gz";
-    name = "3.0.6-1.tar.gz";
-    sha256 = "4f13ff674abc3f297c4e915b4b0fe1b8681e94798f697901c74c45728b4700ef";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/image_view/3.0.7-1.tar.gz";
+    name = "3.0.7-1.tar.gz";
+    sha256 = "8cc0fe48856672886ae5666e9c08b50a6e6941ed3bf39f1904642f75ce2417e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kinova-gen3-6dof-robotiq-2f-85-moveit-config/default.nix
+++ b/distros/humble/kinova-gen3-6dof-robotiq-2f-85-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, joint-state-publisher, joint-state-publisher-gui, kortex-description, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, picknik-reset-fault-controller, picknik-twist-controller, robot-state-publisher, rviz-common, rviz-default-plugins, rviz2, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-kinova-gen3-6dof-robotiq-2f-85-moveit-config";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kinova_gen3_6dof_robotiq_2f_85_moveit_config/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "126785b070e2678b563a0f24db6079fefd6779d46d12ebecd8db48e4aa8ca556";
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kinova_gen3_6dof_robotiq_2f_85_moveit_config/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "94d1894e6b601b96461f6e6da0d3eacba3a6b2f9c1c571abeafc54ed30f6902e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kinova-gen3-7dof-robotiq-2f-85-moveit-config/default.nix
+++ b/distros/humble/kinova-gen3-7dof-robotiq-2f-85-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, joint-state-publisher, joint-state-publisher-gui, kortex-description, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, picknik-reset-fault-controller, picknik-twist-controller, robot-state-publisher, rviz-common, rviz-default-plugins, rviz2, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-kinova-gen3-7dof-robotiq-2f-85-moveit-config";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kinova_gen3_7dof_robotiq_2f_85_moveit_config/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "253daaa8e2f523d38951d6ff0f67496bcc0b877a87c601d8a1947bb8de71d8ec";
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kinova_gen3_7dof_robotiq_2f_85_moveit_config/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "f82ffd43f0664065e41c4e657b78b26f68efe5289a2cacf522f98ef90d6f3375";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kinova-gen3-lite-moveit-config/default.nix
+++ b/distros/humble/kinova-gen3-lite-moveit-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, joint-state-publisher, joint-state-publisher-gui, kortex-description, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, picknik-reset-fault-controller, picknik-twist-controller, robot-state-publisher, rviz-common, rviz-default-plugins, rviz2, tf2-ros, xacro }:
+buildRosPackage {
+  pname = "ros-humble-kinova-gen3-lite-moveit-config";
+  version = "0.2.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kinova_gen3_lite_moveit_config/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "ebe2c4187b80349761d1206a8fd70b5b621202d2d08d8b5e2e2a3effbbadc79a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ controller-manager joint-state-publisher joint-state-publisher-gui kortex-description moveit-configs-utils moveit-kinematics moveit-planners moveit-ros-move-group moveit-ros-visualization moveit-ros-warehouse moveit-setup-assistant moveit-simple-controller-manager picknik-reset-fault-controller picknik-twist-controller robot-state-publisher rviz-common rviz-default-plugins rviz2 tf2-ros xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "An automatically generated package with all the configuration and launch files for using the gen3_lite with the MoveIt Motion Planning Framework";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/kortex-api/default.nix
+++ b/distros/humble/kortex-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-kortex-api";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kortex_api/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "b57e60cf16e5373ff7ee2c095f60d007df753c745c487f06de2246e4062ee4bd";
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kortex_api/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "72bb72039b721b75834bea36c636e6363c2b0796889132f2164085f7c25a80b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kortex-bringup/default.nix
+++ b/distros/humble/kortex-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, gazebo-ros2-control, gripper-controllers, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, kortex-description, kortex-driver, launch, launch-ros, rclpy, robotiq-description, rviz2, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-kortex-bringup";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kortex_bringup/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "3412c424e8723353791ab5acfa51d845a313ed27c0ec45abaf5750404bba1e50";
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kortex_bringup/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "271b55063bc9e5fa063f3c6917b64ea76181411002936f0043d178971e57a9fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kortex-description/default.nix
+++ b/distros/humble/kortex-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, joint-state-publisher-gui, joint-trajectory-controller, picknik-reset-fault-controller, picknik-twist-controller, robot-state-publisher, robotiq-description, rviz2 }:
 buildRosPackage {
   pname = "ros-humble-kortex-description";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kortex_description/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "e3f435aa09fd39732151c98ccdd22c88bd92412fd1f3f5923b6627802c2c5b6f";
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kortex_description/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "c4c71ba783c161b39ebaf61c43ebc79ef0c5241e251d0a4ccd78d9925dbd73ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kortex-driver/default.nix
+++ b/distros/humble/kortex-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, hardware-interface, kortex-api, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-kortex-driver";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kortex_driver/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "789bcb19f13e9f90e0bcc59a47f8e676296e8bf50fd398ca865cc43f6170704e";
+    url = "https://github.com/ros2-gbp/ros2_kortex-release/archive/release/humble/kortex_driver/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "c3dfe586c7fb00f338fc8c657b1103bcff64ef7ee024fd83db517558e1b8f215";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/launch-pal/default.nix
+++ b/distros/humble/launch-pal/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-launch-pal";
-  version = "0.10.0-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/launch_pal-release/archive/release/humble/launch_pal/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "fa31b138956ef9411bb600087a500d992dbc55b8be9295ae86cb357b21a957e6";
+    url = "https://github.com/pal-gbp/launch_pal-release/archive/release/humble/launch_pal/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "69386533c7fcc11c1125038c015edeee8df5304f0525ae4cc00de1ee9031dd9d";
   };
 
   buildType = "ament_python";

--- a/distros/humble/omni-base-2dnav/default.nix
+++ b/distros/humble/omni-base-2dnav/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, nav2-bringup, omni-base-laser-sensors, pal-maps, ros2launch, rviz2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-index-python, ament-lint-auto, ament-lint-common, launch-pal, nav2-bringup, omni-base-laser-sensors, pal-maps, ros2launch, rviz2 }:
 buildRosPackage {
   pname = "ros-humble-omni-base-2dnav";
-  version = "2.4.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_2dnav/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "67b6be996d7a85f47e31d8de1b6404aff1b80975b02bfcf8ba5ca035aea70dbc";
+    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_2dnav/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "bdc802c76565bd59d1f22cbff8d8c74b19af0a51cae625dc98852ab0d7379c0b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ nav2-bringup omni-base-laser-sensors pal-maps ros2launch rviz2 ];
+  propagatedBuildInputs = [ ament-index-python launch-pal nav2-bringup omni-base-laser-sensors pal-maps ros2launch rviz2 ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/omni-base-bringup/default.nix
+++ b/distros/humble/omni-base-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, joy-linux, joy-teleop, launch-pal, omni-base-controller-configuration, omni-base-description, robot-state-publisher, twist-mux }:
 buildRosPackage {
   pname = "ros-humble-omni-base-bringup";
-  version = "2.4.1-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_bringup/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "6223da6ab08431df1a63e01c3f772ee61260cd7f120bb05c2823284c42c323b1";
+    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_bringup/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "8e01ba0750589d6241c78b2333cb560bb3f329e769bdaa2bbb99052b20ed3a77";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-controller-configuration/default.nix
+++ b/distros/humble/omni-base-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, imu-sensor-broadcaster, joint-state-broadcaster, ros2controlcli, topic-tools }:
 buildRosPackage {
   pname = "ros-humble-omni-base-controller-configuration";
-  version = "2.4.1-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_controller_configuration/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "5c5a545bd1f39b4b63711531f0d08f0a566e85a2643b291b894870ab7a9cd688";
+    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_controller_configuration/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "99358a56ff5fbd8928ab24886d65d85191486f0d00bf943b25b1c097da0a23cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-description/default.nix
+++ b/distros/humble/omni-base-description/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-python, ament-lint-auto, ament-lint-common, gazebo-planar-move-plugin, joint-state-publisher-gui, launch, launch-pal, launch-param-builder, launch-ros, launch-testing-ament-cmake, pal-urdf-utils, realsense2-description, rviz2, urdf-test, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, gazebo-planar-move-plugin, joint-state-publisher-gui, launch, launch-pal, launch-param-builder, launch-ros, launch-testing-ament-cmake, pal-urdf-utils, realsense2-description, rviz2, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-omni-base-description";
-  version = "2.4.1-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_description/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "53dcfc837ed002a20443ff71cbe2eb7d1957b30fc8029467e70c333342db173c";
+    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_description/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "1395f7e270632cbf7e1ef2708ea64d144d5e2e611901261385efa0048e3005a7";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ament-cmake-python ];
-  checkInputs = [ ament-lint-auto ament-lint-common launch-testing-ament-cmake urdf-test ];
+  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common launch-testing-ament-cmake urdf-test ];
   propagatedBuildInputs = [ gazebo-planar-move-plugin joint-state-publisher-gui launch launch-pal launch-param-builder launch-ros pal-urdf-utils realsense2-description rviz2 xacro ];
   nativeBuildInputs = [ ament-cmake-auto ament-cmake-python ];
 

--- a/distros/humble/omni-base-gazebo/default.nix
+++ b/distros/humble/omni-base-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, gazebo-plugins, gazebo-ros, gazebo-ros2-control, launch-pal, omni-base-2dnav, omni-base-bringup, omni-base-description, pal-gazebo-plugins, pal-gazebo-worlds }:
 buildRosPackage {
   pname = "ros-humble-omni-base-gazebo";
-  version = "2.2.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_simulation-release/archive/release/humble/omni_base_gazebo/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "ed81ed97f1dfd9815da41b9d70ab49fa589dae2676f0bc25e014cc6bf33059e6";
+    url = "https://github.com/pal-gbp/omni_base_simulation-release/archive/release/humble/omni_base_gazebo/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "52a219a7d2932a721a4b68cd95392a0b534eb7d77108951bac717c085d3d715a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-laser-sensors/default.nix
+++ b/distros/humble/omni-base-laser-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-omni-base-laser-sensors";
-  version = "2.4.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_laser_sensors/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "c4388779b82073bb7a8b38e127c3f0ad353b4242aab427fea165a33ac35622d9";
+    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_laser_sensors/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "e911f1fc5ff72d579751e86587466e0438e1175e9dea5e4fa89392d590b46a7f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-navigation/default.nix
+++ b/distros/humble/omni-base-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, omni-base-2dnav, omni-base-laser-sensors, omni-base-rgbd-sensors }:
 buildRosPackage {
   pname = "ros-humble-omni-base-navigation";
-  version = "2.4.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_navigation/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "35466ce33035d08966f4c066146dfd8b11a9493029407bb0b9c15bb6e34c8c78";
+    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_navigation/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "43c1371ddcab52b212e062bf3d01fabfd6126430055653bc625cd5166b87607d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-rgbd-sensors/default.nix
+++ b/distros/humble/omni-base-rgbd-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-omni-base-rgbd-sensors";
-  version = "2.4.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_rgbd_sensors/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "0e1640406fa1ba75c2599f4205ca163ee6e54c00f82fb16c4224d75bdebed77a";
+    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_rgbd_sensors/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "9ca018c356ec2f598d7d56db262ec7d8b8c601524c16cc95198dcf3840e2cb20";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-robot/default.nix
+++ b/distros/humble/omni-base-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, omni-base-bringup, omni-base-controller-configuration, omni-base-description }:
 buildRosPackage {
   pname = "ros-humble-omni-base-robot";
-  version = "2.4.1-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_robot/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "f9a6c80ac74137c9297a6fdf28555e0805a8ab04b7912566f8b10b05aaa6de14";
+    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_robot/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "92ba4ba37d8cf5410d377e7d321c5e0af3150bc3607aaa488ead3dad425457b9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-simulation/default.nix
+++ b/distros/humble/omni-base-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, omni-base-gazebo }:
 buildRosPackage {
   pname = "ros-humble-omni-base-simulation";
-  version = "2.2.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_simulation-release/archive/release/humble/omni_base_simulation/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "dce66e251c44c33a93efe539f0db2323d25494658047612525cb08668b3e986b";
+    url = "https://github.com/pal-gbp/omni_base_simulation-release/archive/release/humble/omni_base_simulation/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "9d8344a16020a23fb96392909353abef23756d8d5971cd44f701fda821bc1f7b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-gripper-controller-configuration/default.nix
+++ b/distros/humble/pal-gripper-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, joint-trajectory-controller, position-controllers }:
 buildRosPackage {
   pname = "ros-humble-pal-gripper-controller-configuration";
-  version = "3.4.0-r1";
+  version = "3.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper_controller_configuration/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "1f75bb3000681bb9e8d86e55b21fbf71cef14f0c831377ac65695224e89b8330";
+    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper_controller_configuration/3.5.0-1.tar.gz";
+    name = "3.5.0-1.tar.gz";
+    sha256 = "92d0d326558df6aa67ab35ae58e74c1716230ecf42761adfd80c15e9e8229340";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-gripper-description/default.nix
+++ b/distros/humble/pal-gripper-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, pal-urdf-utils, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-pal-gripper-description";
-  version = "3.4.0-r1";
+  version = "3.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper_description/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "c661613d768edfeb3f68e1e578bae27a515a11b758b91a9cab3a2cf5efe25044";
+    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper_description/3.5.0-1.tar.gz";
+    name = "3.5.0-1.tar.gz";
+    sha256 = "37735ca9addf244232413c34a187968f4ff764e36cc3dcb69a28af1faa1551f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-gripper-simulation/default.nix
+++ b/distros/humble/pal-gripper-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, pal-gazebo-worlds, pal-gripper-controller-configuration, pal-gripper-description, pal-urdf-utils, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-humble-pal-gripper-simulation";
-  version = "3.4.0-r1";
+  version = "3.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper_simulation/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "03843b2439224c89916907746dcc54bfd9d7bf79dedcbb98cf2c7e7265d8ddc4";
+    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper_simulation/3.5.0-1.tar.gz";
+    name = "3.5.0-1.tar.gz";
+    sha256 = "6972d4e5d17fd0ad6846c005bda2cc6796d7897843962b18f8addbf6c3979a1a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-gripper/default.nix
+++ b/distros/humble/pal-gripper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pal-gripper-controller-configuration, pal-gripper-description }:
 buildRosPackage {
   pname = "ros-humble-pal-gripper";
-  version = "3.4.0-r1";
+  version = "3.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "886de4f575adbd0dbe6e98c7d29d96c65d4eb0d73f4df0f3014d8ba2a0fc0270";
+    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper/3.5.0-1.tar.gz";
+    name = "3.5.0-1.tar.gz";
+    sha256 = "c3cc3dda353729087c07d6bb816cd673b0de320887590c4ec62101fc401a9a06";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/play-motion2-msgs/default.nix
+++ b/distros/humble/play-motion2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-play-motion2-msgs";
-  version = "1.3.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/play_motion2-release/archive/release/humble/play_motion2_msgs/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "14180b79ec6eb039349034cd9376d7ce1957d9f3285b48e6df88dd52165fb48d";
+    url = "https://github.com/pal-gbp/play_motion2-release/archive/release/humble/play_motion2_msgs/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "23a2accb6ab5703f5fdb651cc4a8e755a1ecb55bea906f1e8bcf2894cad16660";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/play-motion2/default.nix
+++ b/distros/humble/play-motion2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, control-msgs, controller-manager, controller-manager-msgs, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-pal, launch-ros, launch-testing-ament-cmake, lifecycle-msgs, moveit-ros-planning-interface, play-motion2-msgs, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, robot-state-publisher, sensor-msgs, std-msgs, trajectory-msgs, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, control-msgs, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-pal, launch-ros, launch-testing-ament-cmake, lifecycle-msgs, moveit-ros-planning-interface, play-motion2-msgs, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, realtime-tools, robot-state-publisher, sensor-msgs, std-msgs, trajectory-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-play-motion2";
-  version = "1.3.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/play_motion2-release/archive/release/humble/play_motion2/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "0ad3fa0dac28d73b774170b98b3366ea2b20bf9bf6aeef5643d471dde52d104b";
+    url = "https://github.com/pal-gbp/play_motion2-release/archive/release/humble/play_motion2/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "339b737b757de74b721f2b4692c23b6cfd11c4140bc557fa54aace6af1092e39";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
-  checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ament-lint-common controller-manager hardware-interface joint-state-broadcaster joint-trajectory-controller launch-pal launch-testing-ament-cmake pluginlib robot-state-publisher xacro ];
+  checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ament-lint-common controller-interface controller-manager hardware-interface joint-state-broadcaster joint-trajectory-controller launch-pal launch-testing-ament-cmake pluginlib realtime-tools robot-state-publisher sensor-msgs xacro ];
   propagatedBuildInputs = [ control-msgs controller-manager-msgs launch launch-ros lifecycle-msgs moveit-ros-planning-interface play-motion2-msgs rclcpp rclcpp-action rclcpp-lifecycle sensor-msgs std-msgs trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake-auto ];
 

--- a/distros/humble/pmb2-2dnav/default.nix
+++ b/distros/humble/pmb2-2dnav/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, launch-pal, nav2-bringup, pal-maps, pmb2-laser-sensors, ros2launch, rviz2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-index-python, ament-lint-auto, ament-lint-common, launch-pal, nav2-bringup, pal-maps, pmb2-laser-sensors, ros2launch, rviz2 }:
 buildRosPackage {
   pname = "ros-humble-pmb2-2dnav";
-  version = "4.5.0-r1";
+  version = "4.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_2dnav/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "0927ccb4687b0c755d37800490acd7dc90b79202d0895ed479eaf131654643fc";
+    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_2dnav/4.11.0-1.tar.gz";
+    name = "4.11.0-1.tar.gz";
+    sha256 = "1f88acddb71c5ed6b61981461d227ef6028c46c8734193c9d8fb10cba2e27b55";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ launch-pal nav2-bringup pal-maps pmb2-laser-sensors ros2launch rviz2 ];
+  propagatedBuildInputs = [ ament-index-python launch-pal nav2-bringup pal-maps pmb2-laser-sensors ros2launch rviz2 ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/pmb2-bringup/default.nix
+++ b/distros/humble/pmb2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, geometry-msgs, joy-linux, joy-teleop, launch-pal, pmb2-controller-configuration, pmb2-description, robot-state-publisher, twist-mux, twist-mux-msgs }:
 buildRosPackage {
   pname = "ros-humble-pmb2-bringup";
-  version = "5.4.0-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_bringup/5.4.0-1.tar.gz";
-    name = "5.4.0-1.tar.gz";
-    sha256 = "c96cc54c59c4d8aa7e2958c0373545895f0ac919054cd461a1cbd9e2e985d654";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_bringup/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "c05d02537657e73d7c48224981202cdc95f6ac9b775377237c80bbb320f53d8e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-controller-configuration/default.nix
+++ b/distros/humble/pmb2-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, diff-drive-controller, imu-sensor-broadcaster, joint-state-broadcaster, launch, launch-pal, ros2controlcli }:
 buildRosPackage {
   pname = "ros-humble-pmb2-controller-configuration";
-  version = "5.4.0-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_controller_configuration/5.4.0-1.tar.gz";
-    name = "5.4.0-1.tar.gz";
-    sha256 = "8cd319479e184c214be4b3566b670923fbfc2325363d31c2be64f21849b3e064";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_controller_configuration/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "79848d6d65d627295e001ae0de5b40e60e68aca21d83f9b228e17561760e128b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-description/default.nix
+++ b/distros/humble/pmb2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, joint-state-publisher-gui, launch, launch-pal, launch-param-builder, launch-ros, launch-testing-ament-cmake, pal-urdf-utils, rviz2, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-pmb2-description";
-  version = "5.4.0-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_description/5.4.0-1.tar.gz";
-    name = "5.4.0-1.tar.gz";
-    sha256 = "e5f53ee783b6506cbea47d5d64aa26606bf246e61fcddbece7d3e395cf3bd9a1";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_description/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "3f20c9a3fbee9305e77466625bf5e2b467f33c7228c8b31127d9ad3c4fe09ec8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-gazebo/default.nix
+++ b/distros/humble/pmb2-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, gazebo-plugins, gazebo-ros, gazebo-ros2-control, launch-pal, pal-gazebo-plugins, pal-gazebo-worlds, pmb2-2dnav, pmb2-bringup, pmb2-description }:
 buildRosPackage {
   pname = "ros-humble-pmb2-gazebo";
-  version = "4.1.0-r1";
+  version = "4.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_simulation-release/archive/release/humble/pmb2_gazebo/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "74e5cf2e77341cf41cd8ddbdc2fb61845ae8f57afb8df264a9bdbb44c8325d62";
+    url = "https://github.com/pal-gbp/pmb2_simulation-release/archive/release/humble/pmb2_gazebo/4.3.0-1.tar.gz";
+    name = "4.3.0-1.tar.gz";
+    sha256 = "77e8a01d844ae49b55e76f3d12984cfe180f12a8806364bf3c7f055ca0125794";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-laser-sensors/default.nix
+++ b/distros/humble/pmb2-laser-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-pmb2-laser-sensors";
-  version = "4.5.0-r1";
+  version = "4.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_laser_sensors/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "5077aaa88838c96de317dbffed9992ac1ec651887fe885fc6efbf18a2ae0bf05";
+    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_laser_sensors/4.11.0-1.tar.gz";
+    name = "4.11.0-1.tar.gz";
+    sha256 = "c2c01e3b8e632d3bc9eb5939da9366d088e12338383cd433ce3acc6baae0aeb1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-navigation/default.nix
+++ b/distros/humble/pmb2-navigation/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, pmb2-2dnav, pmb2-laser-sensors }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, pmb2-2dnav, pmb2-laser-sensors, pmb2-rgbd-sensors }:
 buildRosPackage {
   pname = "ros-humble-pmb2-navigation";
-  version = "4.5.0-r1";
+  version = "4.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_navigation/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "f8983f22cb4c78df49a1bf8eb1d01587a90c179c3b5c49e5be118cb22d1b8c4b";
+    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_navigation/4.11.0-1.tar.gz";
+    name = "4.11.0-1.tar.gz";
+    sha256 = "cc8aeafd9b22c0b4ae6836db17e634785b727908f09664dae76a20ecec03ffc5";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
-  propagatedBuildInputs = [ pmb2-2dnav pmb2-laser-sensors ];
+  propagatedBuildInputs = [ pmb2-2dnav pmb2-laser-sensors pmb2-rgbd-sensors ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/pmb2-rgbd-sensors/default.nix
+++ b/distros/humble/pmb2-rgbd-sensors/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-humble-pmb2-rgbd-sensors";
+  version = "4.11.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_rgbd_sensors/4.11.0-1.tar.gz";
+    name = "4.11.0-1.tar.gz";
+    sha256 = "951d09546a09ab0825e5861d09695e52889aa01000a18992ddcee85ba5eef98e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-auto ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = "pmb2-specific RGBD sensors module and params files.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/pmb2-robot/default.nix
+++ b/distros/humble/pmb2-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pmb2-bringup, pmb2-controller-configuration, pmb2-description }:
 buildRosPackage {
   pname = "ros-humble-pmb2-robot";
-  version = "5.4.0-r1";
+  version = "5.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_robot/5.4.0-1.tar.gz";
-    name = "5.4.0-1.tar.gz";
-    sha256 = "4852aed11c34382c80295c26b7e2973d002b3be0351c6eefa4369a2cc0e87702";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_robot/5.7.0-1.tar.gz";
+    name = "5.7.0-1.tar.gz";
+    sha256 = "fd85400824adabbc3a99d3b9db00b94640f614941774220a39a9539be7075ef4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-simulation/default.nix
+++ b/distros/humble/pmb2-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pmb2-gazebo }:
 buildRosPackage {
   pname = "ros-humble-pmb2-simulation";
-  version = "4.1.0-r1";
+  version = "4.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_simulation-release/archive/release/humble/pmb2_simulation/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "6c0b0e4f4bb12e08aec33dd694fe2fe9061ac0b943ecc3ed12a304ba5654afc9";
+    url = "https://github.com/pal-gbp/pmb2_simulation-release/archive/release/humble/pmb2_simulation/4.3.0-1.tar.gz";
+    name = "4.3.0-1.tar.gz";
+    sha256 = "6bff19f74f796d8f4b95cdd7e8bc0a414e277c2a50f3bb0db9b6789c69278e05";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/realtime-tools/default.nix
+++ b/distros/humble/realtime-tools/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, libcap, lifecycle-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, boost, libcap, lifecycle-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-realtime-tools";
-  version = "2.11.0-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/humble/realtime_tools/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "68ad811500425329746cab5c48ee54c8ebd0129b5cea435f52b1702fbf6edd11";
+    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/humble/realtime_tools/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "d26f45c4d0d3f90e1de029a160ec665529ea618dd3d7776af15a32b5873617c2";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gmock lifecycle-msgs rclcpp-lifecycle test-msgs ];
-  propagatedBuildInputs = [ ament-cmake libcap rclcpp rclcpp-action ];
+  propagatedBuildInputs = [ ament-cmake boost libcap rclcpp rclcpp-action ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/rmw-desert/default.nix
+++ b/distros/humble/rmw-desert/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-cmake, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
+buildRosPackage {
+  pname = "ros-humble-rmw-desert";
+  version = "1.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmw_desert-release/archive/release/humble/rmw_desert/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "7f2e283844bfe55898548ae55a12e4ad40d6d177d414f00efe4cc5db6f8fc8aa";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  propagatedBuildInputs = [ ament-cmake rcpputils rcutils rmw rmw-dds-common rosidl-cmake rosidl-runtime-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros rosidl-cmake ];
+
+  meta = {
+    description = "Implement the ROS middleware interface using the DESERT protocol stack for underwater communications.";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/humble/stereo-image-proc/default.nix
+++ b/distros/humble/stereo-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-geometry, image-proc, image-transport, launch, launch-ros, launch-testing, launch-testing-ament-cmake, message-filters, python-cmake-module, python3Packages, rclcpp, rclcpp-components, rclpy, ros-testing, sensor-msgs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-humble-stereo-image-proc";
-  version = "3.0.6-r1";
+  version = "3.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/stereo_image_proc/3.0.6-1.tar.gz";
-    name = "3.0.6-1.tar.gz";
-    sha256 = "19d0ee0d723db9949185849bef5db71a870f96f71d9e901c3685c141c1161f20";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/stereo_image_proc/3.0.7-1.tar.gz";
+    name = "3.0.7-1.tar.gz";
+    sha256 = "52de776608da2da78b6b55db29e6dc338de615cc44a059b4c94e0c484a0348a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/talos-moveit-config/default.nix
+++ b/distros/humble/talos-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, launch-pal, moveit-configs-utils, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-perception, moveit-ros-visualization, moveit-simple-controller-manager, talos-description }:
 buildRosPackage {
   pname = "ros-humble-talos-moveit-config";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/talos_moveit_config-release/archive/release/humble/talos_moveit_config/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "8f13ff4ebc366a30a632b64dfc7e29e4d76c3794e496f0805bd00adfa37fbe7b";
+    url = "https://github.com/pal-gbp/talos_moveit_config-release/archive/release/humble/talos_moveit_config/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "41ce5c1b5302b15741ba97ad4111366863ed387201ff9e6fcf764cba68cb41ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-2dnav/default.nix
+++ b/distros/humble/tiago-2dnav/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, launch-pal, nav2-bringup, pal-maps, ros2launch, rviz2, tiago-description, tiago-laser-sensors }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-index-python, ament-lint-auto, ament-lint-common, launch-pal, nav2-bringup, omni-base-2dnav, pal-maps, pmb2-2dnav, ros2launch, rviz2, tiago-description }:
 buildRosPackage {
   pname = "ros-humble-tiago-2dnav";
-  version = "4.5.0-r1";
+  version = "4.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_2dnav/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "f812c83f83256345e7f3011bb09aca8304347627c768cfb6be685a8e9b7b146b";
+    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_2dnav/4.9.0-1.tar.gz";
+    name = "4.9.0-1.tar.gz";
+    sha256 = "ef5fc8ca32934f39b9f4c6d9e17b52f86a431e47a2e9687f5f99fc5c89e6ae74";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ launch-pal nav2-bringup pal-maps ros2launch rviz2 tiago-description tiago-laser-sensors ];
+  propagatedBuildInputs = [ ament-index-python launch-pal nav2-bringup omni-base-2dnav pal-maps pmb2-2dnav ros2launch rviz2 tiago-description ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/tiago-bringup/default.nix
+++ b/distros/humble/tiago-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, geometry-msgs, joy-linux, joy-teleop, launch-pal, play-motion2, teleop-tools-msgs, tiago-controller-configuration, tiago-description, twist-mux, twist-mux-msgs }:
 buildRosPackage {
   pname = "ros-humble-tiago-bringup";
-  version = "4.7.1-r1";
+  version = "4.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_bringup/4.7.1-1.tar.gz";
-    name = "4.7.1-1.tar.gz";
-    sha256 = "628d242443b631c4a8761fa731968bd447070fa673073451a49edc28529866c6";
+    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_bringup/4.14.0-1.tar.gz";
+    name = "4.14.0-1.tar.gz";
+    sha256 = "81a0d420e8efe95fd7a4fa681bdd75fa788a7420f61d8465c1b2020c5aba3264";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-controller-configuration/default.nix
+++ b/distros/humble/tiago-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, diff-drive-controller, force-torque-sensor-broadcaster, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-pal, omni-base-controller-configuration, pal-gripper-controller-configuration, pal-hey5-controller-configuration, pal-robotiq-controller-configuration, pmb2-controller-configuration, ros2controlcli }:
 buildRosPackage {
   pname = "ros-humble-tiago-controller-configuration";
-  version = "4.7.1-r1";
+  version = "4.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_controller_configuration/4.7.1-1.tar.gz";
-    name = "4.7.1-1.tar.gz";
-    sha256 = "c600202b5907f346efa535e4ff83a48de36ee7ebb3f2594fd2de2181177b614d";
+    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_controller_configuration/4.14.0-1.tar.gz";
+    name = "4.14.0-1.tar.gz";
+    sha256 = "ab9fdc3afd091b1f11447970a69644f09fd1c510afc51a63f48aa48d5d43a860";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-description/default.nix
+++ b/distros/humble/tiago-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, launch, launch-pal, launch-param-builder, launch-ros, launch-testing-ament-cmake, omni-base-description, pal-gripper-description, pal-hey5-description, pal-robotiq-description, pal-urdf-utils, pmb2-description, robot-state-publisher, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-tiago-description";
-  version = "4.7.1-r1";
+  version = "4.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_description/4.7.1-1.tar.gz";
-    name = "4.7.1-1.tar.gz";
-    sha256 = "8f05038219faa736d38119660b7ad6e3f040ac6d4a11c38e1d58fc0a05a8d76b";
+    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_description/4.14.0-1.tar.gz";
+    name = "4.14.0-1.tar.gz";
+    sha256 = "d2e8c9ecd71bbfc86119eb566bdfe75e2f0195d615970e4b7ee6b22daeee2185";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-laser-sensors/default.nix
+++ b/distros/humble/tiago-laser-sensors/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, omni-base-laser-sensors, pmb2-laser-sensors }:
 buildRosPackage {
   pname = "ros-humble-tiago-laser-sensors";
-  version = "4.5.0-r1";
+  version = "4.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_laser_sensors/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "ce9f1d8e9ef0fd59bd7431113e7f7c3f4f73e6aadeb1e3879dca92ccb9d7e3d5";
+    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_laser_sensors/4.9.0-1.tar.gz";
+    name = "4.9.0-1.tar.gz";
+    sha256 = "09cdabce7e3ab62bea885e2d295f23689b1ff8607f55ea534ba6eb71157bd043";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ omni-base-laser-sensors pmb2-laser-sensors ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/tiago-moveit-config/default.nix
+++ b/distros/humble/tiago-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-pal, moveit-configs-utils, moveit-kinematics, moveit-planners-ompl, moveit-ros-control-interface, moveit-ros-move-group, moveit-ros-perception, moveit-ros-visualization, tiago-description }:
 buildRosPackage {
   pname = "ros-humble-tiago-moveit-config";
-  version = "3.1.1-r1";
+  version = "3.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_moveit_config-release/archive/release/humble/tiago_moveit_config/3.1.1-1.tar.gz";
-    name = "3.1.1-1.tar.gz";
-    sha256 = "975a951ce3b088eba2a3557a0a351ad62ba946dc550d15732b6926097422f4fb";
+    url = "https://github.com/pal-gbp/tiago_moveit_config-release/archive/release/humble/tiago_moveit_config/3.1.2-1.tar.gz";
+    name = "3.1.2-1.tar.gz";
+    sha256 = "9e681ab6e59a8a1edb16fe4c5e29463cdfcc18eae842d769a8336f602ffcb72f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-navigation/default.nix
+++ b/distros/humble/tiago-navigation/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, tiago-2dnav, tiago-laser-sensors }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, tiago-2dnav, tiago-laser-sensors, tiago-rgbd-sensors }:
 buildRosPackage {
   pname = "ros-humble-tiago-navigation";
-  version = "4.5.0-r1";
+  version = "4.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_navigation/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "7275a40bfdd9a2735e0e1eee8c2dbe7a7007d37c5de8f871d1faef415ad9cc67";
+    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_navigation/4.9.0-1.tar.gz";
+    name = "4.9.0-1.tar.gz";
+    sha256 = "4e5acd611efb937de2032043b180769e63e83b3f9611f5af1af1c29c696da904";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
-  propagatedBuildInputs = [ tiago-2dnav tiago-laser-sensors ];
+  propagatedBuildInputs = [ tiago-2dnav tiago-laser-sensors tiago-rgbd-sensors ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/tiago-rgbd-sensors/default.nix
+++ b/distros/humble/tiago-rgbd-sensors/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-humble-tiago-rgbd-sensors";
+  version = "4.9.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_rgbd_sensors/4.9.0-1.tar.gz";
+    name = "4.9.0-1.tar.gz";
+    sha256 = "7d0b4c1dc7b527d20ffae42adaa9f2463d1dc0172497b9cb83e8c866b098b476";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-auto ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = "Launch files and scripts needed to bring up the ROS nodes of a TIAGo robot.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/tiago-robot/default.nix
+++ b/distros/humble/tiago-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tiago-bringup, tiago-controller-configuration, tiago-description }:
 buildRosPackage {
   pname = "ros-humble-tiago-robot";
-  version = "4.7.1-r1";
+  version = "4.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_robot/4.7.1-1.tar.gz";
-    name = "4.7.1-1.tar.gz";
-    sha256 = "d0946c8b859f46fba4cc4eb136764af7821bbecc45fd237d0ff41bd749013387";
+    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_robot/4.14.0-1.tar.gz";
+    name = "4.14.0-1.tar.gz";
+    sha256 = "4c0603cb01d5d8c8cb06b16c0da9f79d712a348d362bcd8654422ebab00cf517";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tracetools-image-pipeline/default.nix
+++ b/distros/humble/tracetools-image-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, pkg-config }:
 buildRosPackage {
   pname = "ros-humble-tracetools-image-pipeline";
-  version = "3.0.6-r1";
+  version = "3.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/tracetools_image_pipeline/3.0.6-1.tar.gz";
-    name = "3.0.6-1.tar.gz";
-    sha256 = "91f8c5a4b0f3cd4637eea7538a4a6fe56402e1323e7cfb05522c82391a76c25a";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/tracetools_image_pipeline/3.0.7-1.tar.gz";
+    name = "3.0.7-1.tar.gz";
+    sha256 = "4310c6be9a06fcfaf11050d82d50c1ca415aad0608b8443dee5496def472c136";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot4-ignition-bringup/default.nix
+++ b/distros/humble/turtlebot4-ignition-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, irobot-create-common-bringup, irobot-create-description, irobot-create-ignition-bringup, irobot-create-ignition-toolbox, irobot-create-msgs, irobot-create-nodes, irobot-create-toolbox, ros-ign-bridge, ros-ign-gazebo, ros-ign-interfaces, std-msgs, turtlebot4-description, turtlebot4-ignition-gui-plugins, turtlebot4-ignition-toolbox, turtlebot4-msgs, turtlebot4-navigation, turtlebot4-node, turtlebot4-viz }:
 buildRosPackage {
   pname = "ros-humble-turtlebot4-ignition-bringup";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/humble/turtlebot4_ignition_bringup/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "e7202273a2c12137662f26a6d7e9e6982419c276996115e97c5e54541c2781a3";
+    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/humble/turtlebot4_ignition_bringup/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "b816e7e6b7bdaa03ad86366133d146b4a5bf605eb37b1ada53ec359ac87572da";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot4-ignition-toolbox/default.nix
+++ b/distros/humble/turtlebot4-ignition-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-action, rcutils, ros-ign-interfaces, sensor-msgs, std-msgs, turtlebot4-msgs }:
 buildRosPackage {
   pname = "ros-humble-turtlebot4-ignition-toolbox";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/humble/turtlebot4_ignition_toolbox/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "42658e3d77806f03ce146c03f26054dededc699ed0918741df345f7074104257";
+    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/humble/turtlebot4_ignition_toolbox/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "52ecf57a2b4dae61d1471cfdd4dafb0265adbf1367eb504f5ea6ebfa68fdcbdb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot4-setup/default.nix
+++ b/distros/humble/turtlebot4-setup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, chrony, curl, networkmanager, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, robot-upstart, simple-term-menu-vendor }:
 buildRosPackage {
   pname = "ros-humble-turtlebot4-setup";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4_setup-release/archive/release/humble/turtlebot4_setup/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "0b60e5a227ad22c4ff7cfb2c02e5642b0e4377727aea6682022a549179c10cd3";
+    url = "https://github.com/ros2-gbp/turtlebot4_setup-release/archive/release/humble/turtlebot4_setup/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "3766d48214005c6b1afc6be78b424a46fbcca4e0182b8a498e8d960da357300b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot4-simulator/default.nix
+++ b/distros/humble/turtlebot4-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, turtlebot4-ignition-bringup, turtlebot4-ignition-gui-plugins, turtlebot4-ignition-toolbox }:
 buildRosPackage {
   pname = "ros-humble-turtlebot4-simulator";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/humble/turtlebot4_simulator/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "115f69a45730f80728a1e1dd715bd178e7ea7ca2681504a9246a5a1dab78d93c";
+    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/humble/turtlebot4_simulator/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "3b4098ed98500027d369eeb34e6997c6937c5262eaafeda87c6230e73f5e3601";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/wireless-msgs/default.nix
+++ b/distros/humble/wireless-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-wireless-msgs";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/wireless-release/archive/release/humble/wireless_msgs/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "7e5cd5e7b657f5fc71e8950c91fa3850c9ada76d7c4e1fd74b8363684e961e86";
+    url = "https://github.com/clearpath-gbp/wireless-release/archive/release/humble/wireless_msgs/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "56ead653062f82acad8df037b22f51cdf2ec70389eb524a9cba2e31410fa6207";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/wireless-watcher/default.nix
+++ b/distros/humble/wireless-watcher/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, rclcpp, wireless-msgs, wirelesstools }:
+{ lib, buildRosPackage, fetchurl, diagnostic-updater, rclcpp, wireless-msgs, wirelesstools }:
 buildRosPackage {
   pname = "ros-humble-wireless-watcher";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/wireless-release/archive/release/humble/wireless_watcher/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "7a63802fe7418741ba7ff3f1ab18ca5cceb6b6f1d2933ea916906b4d977fc264";
+    url = "https://github.com/clearpath-gbp/wireless-release/archive/release/humble/wireless_watcher/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "7815cbb2e4cabac8be536ce26cddd61e593e47bda48d0701d5f6c8d831ca1fd7";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ rclcpp wireless-msgs wirelesstools ];
+  propagatedBuildInputs = [ diagnostic-updater rclcpp wireless-msgs wirelesstools ];
 
   meta = {
     description = "A node which publishes connection information about a linux wireless interface.";

--- a/distros/jazzy/ackermann-steering-controller/default.nix
+++ b/distros/jazzy/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-ackermann-steering-controller";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ackermann_steering_controller/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "be021b6d549af60c07c229c0db3179a8ed43d4c364bb0d0ccc153a8accc44c89";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ackermann_steering_controller/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "b96030c642f4f5069af7711e31f61a7986cade5be1c7cc4f1d9b81ffc44c22b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/admittance-controller/default.nix
+++ b/distros/jazzy/admittance-controller/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-admittance-controller";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/admittance_controller/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "7073ad60e8d1942d1ff21f9146428280e94100079b612d4dba6db0ff7ad8aa52";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/admittance_controller/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "310db0d372ad11468a89635728ca71e75969ae4a81375b918bacaf8d7b5efca9";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing kinematics-interface-kdl ros2-control-test-assets ];
-  propagatedBuildInputs = [ backward-ros control-msgs control-toolbox controller-interface filters generate-parameter-library geometry-msgs hardware-interface joint-trajectory-controller kinematics-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools tf2 tf2-eigen tf2-geometry-msgs tf2-kdl tf2-ros trajectory-msgs ];
+  propagatedBuildInputs = [ angles backward-ros control-msgs control-toolbox controller-interface generate-parameter-library geometry-msgs hardware-interface kinematics-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools tf2 tf2-eigen tf2-geometry-msgs tf2-kdl tf2-ros trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/apriltag-detector-mit/default.nix
+++ b/distros/jazzy/apriltag-detector-mit/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, apriltag-detector, apriltag-mit, apriltag-msgs, pluginlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-apriltag-detector-mit";
+  version = "3.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/jazzy/apriltag_detector_mit/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "26862b40b33cf65bc6cdfd9eb9105ee9da256e00d0158d7fb9d842e40d78cd5e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ros-environment ];
+  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ apriltag-detector apriltag-mit apriltag-msgs pluginlib rclcpp rclcpp-components sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ros-environment ];
+
+  meta = {
+    description = "ROS package for apriltag detection with MIT detector";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/apriltag-detector-umich/default.nix
+++ b/distros/jazzy/apriltag-detector-umich/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, apriltag, apriltag-detector, apriltag-msgs, opencv, pluginlib, rclcpp, ros-environment, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-apriltag-detector-umich";
+  version = "3.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/jazzy/apriltag_detector_umich/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "444226c5aeadfd54725f1d321a7648254acb8ad09a499bb9646ddcb1eabb9eec";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ros-environment ];
+  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ apriltag apriltag-detector apriltag-msgs opencv opencv.cxxdev pluginlib rclcpp sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ros-environment ];
+
+  meta = {
+    description = "ROS package for apriltag detection with the UMich detector";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/apriltag-detector/default.nix
+++ b/distros/jazzy/apriltag-detector/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, apriltag, apriltag-msgs, cv-bridge, image-transport, rclcpp, rclcpp-components, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, apriltag-msgs, cv-bridge, image-transport, pluginlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-apriltag-detector";
-  version = "1.0.0-r3";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/jazzy/apriltag_detector/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "b846e5b55477dfbe391988911f40f91e166914467ec61e06d4380fd5e3d1226a";
+    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/jazzy/apriltag_detector/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "4e30916df3dac56356c174941dae03f9b111141968c62cb5828372124f3314d9";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ];
+  buildInputs = [ ament-cmake ros-environment ];
   checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ apriltag apriltag-msgs cv-bridge image-transport rclcpp rclcpp-components sensor-msgs ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ];
+  propagatedBuildInputs = [ apriltag-msgs cv-bridge image-transport pluginlib rclcpp rclcpp-components sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ros-environment ];
 
   meta = {
-    description = "ROS package for apriltag detection";
+    description = "ROS2 package for apriltag detection";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/jazzy/apriltag-draw/default.nix
+++ b/distros/jazzy/apriltag-draw/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, apriltag-msgs, cv-bridge, image-transport, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-apriltag-draw";
+  version = "3.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/jazzy/apriltag_draw/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "16bd7c2a34f2d3693227b37e34707d8d71d4b2312d39b94b0e0266d07c8d811c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment ];
+  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ apriltag-msgs cv-bridge image-transport rclcpp rclcpp-components sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ros-environment ];
+
+  meta = {
+    description = "ROS package for drawing apriltags on image";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/apriltag-tools/default.nix
+++ b/distros/jazzy/apriltag-tools/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, apriltag-detector, apriltag-draw, apriltag-msgs, rclcpp, ros-environment, rosbag2-transport }:
+buildRosPackage {
+  pname = "ros-jazzy-apriltag-tools";
+  version = "3.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/jazzy/apriltag_tools/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "e5b10bdd4ec8532ebc5dddb14ae4a1337115bf2f55de00dba59a3f3611e90e42";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment ];
+  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ apriltag-detector apriltag-draw apriltag-msgs rclcpp rosbag2-transport ];
+  nativeBuildInputs = [ ament-cmake ros-environment ];
+
+  meta = {
+    description = "misc tools for working with apriltags under ROS2";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/bicycle-steering-controller/default.nix
+++ b/distros/jazzy/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-bicycle-steering-controller";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/bicycle_steering_controller/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "de93829a3de7f82c38a47c6be27a63d1bde94d79440ebd118f1341376d0ef7ea";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/bicycle_steering_controller/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "f133772acff101e507c79ac66c867d7b3ffeb14e2546a7fa2aa7db0de6e93776";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/camera-calibration/default.nix
+++ b/distros/jazzy/camera-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, cv-bridge, image-geometry, message-filters, python3Packages, rclpy, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-camera-calibration";
-  version = "5.0.8-r1";
+  version = "5.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/camera_calibration/5.0.8-1.tar.gz";
-    name = "5.0.8-1.tar.gz";
-    sha256 = "138c6ed98c42410c1305aaf8643012efe6662168618b8db28b58d34865090136";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/camera_calibration/5.0.9-1.tar.gz";
+    name = "5.0.9-1.tar.gz";
+    sha256 = "9856cc2acbd3581f13cea009fcfa188376aa21296d64f6049596e0191dc68aae";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/controller-interface/default.nix
+++ b/distros/jazzy/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, geometry-msgs, hardware-interface, rclcpp-lifecycle, realtime-tools, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-controller-interface";
-  version = "4.26.0-r1";
+  version = "4.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_interface/4.26.0-1.tar.gz";
-    name = "4.26.0-1.tar.gz";
-    sha256 = "2689a23dd9235888e1fcd1900cacac4f4ff9d8a735226a263b1c51a2ddd47132";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_interface/4.27.0-1.tar.gz";
+    name = "4.27.0-1.tar.gz";
+    sha256 = "b91eadb90d0dc325992d83e60ef5f7a2c8d337a87bca1aca2e0412c78ef003ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/controller-manager-msgs/default.nix
+++ b/distros/jazzy/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-controller-manager-msgs";
-  version = "4.26.0-r1";
+  version = "4.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager_msgs/4.26.0-1.tar.gz";
-    name = "4.26.0-1.tar.gz";
-    sha256 = "fb0ffcdd99c29ccfc9a5a792746316a0b913bd44648fd18688fb75541683ff4e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager_msgs/4.27.0-1.tar.gz";
+    name = "4.27.0-1.tar.gz";
+    sha256 = "a055ad0473d61bfaa07a3400052ef9acc37ea2b4a6a1ed8a4552685ddcc1136d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/controller-manager/default.nix
+++ b/distros/jazzy/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, example-interfaces, generate-parameter-library, hardware-interface, hardware-interface-testing, launch, launch-ros, launch-testing, launch-testing-ros, libstatistics-collector, pluginlib, python3Packages, rclcpp, rclpy, rcpputils, realtime-tools, robot-state-publisher, ros2-control-test-assets, ros2param, ros2run, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-controller-manager";
-  version = "4.26.0-r1";
+  version = "4.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager/4.26.0-1.tar.gz";
-    name = "4.26.0-1.tar.gz";
-    sha256 = "7c1f0c32d0585e4a2a939e99b2015afc37a0cedf79429207861ba21d7a260394";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager/4.27.0-1.tar.gz";
+    name = "4.27.0-1.tar.gz";
+    sha256 = "2b456e2c4b71c01c75d667c467b55c26f0bbfff482d82122b4bfaa98b80dea33";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depth-image-proc/default.nix
+++ b/distros/jazzy/depth-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, class-loader, cv-bridge, image-geometry, image-proc, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, stereo-msgs, tf2, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-depth-image-proc";
-  version = "5.0.8-r1";
+  version = "5.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/depth_image_proc/5.0.8-1.tar.gz";
-    name = "5.0.8-1.tar.gz";
-    sha256 = "55c2288bad9bd56325036b5878b602a1d99f69b42a4bf2a5c12f22234d17831f";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/depth_image_proc/5.0.9-1.tar.gz";
+    name = "5.0.9-1.tar.gz";
+    sha256 = "a57945d363485655768e39067e1d6ad5ff49b99b46cdd352ed2c2491938e9820";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/diff-drive-controller/default.nix
+++ b/distros/jazzy/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-diff-drive-controller";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/diff_drive_controller/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "161ce33e26e64221e9c4fd0cdac6c09593a98155dbb78e506ae0552c84922c6a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/diff_drive_controller/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "d00f2ef5438056846677074307d4b5443c7cb8f21c3ace8afebf9c228175cf68";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/effort-controllers/default.nix
+++ b/distros/jazzy/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-effort-controllers";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/effort_controllers/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "71274028c26d870bac6ab8d3d8ce71f440b763be2702dccd5a94d34c1ea97e37";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/effort_controllers/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "54d95f492ef3d3bbdd8219965879596404860171c7d8ccf1119e40dda9a0e9ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/force-torque-sensor-broadcaster/default.nix
+++ b/distros/jazzy/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-force-torque-sensor-broadcaster";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/force_torque_sensor_broadcaster/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "26d3358f3518404c110724eb5678a49c45a814bff778ed5a8e8dd74d38d80b48";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/force_torque_sensor_broadcaster/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "a23e8f7e8478206a36cc5952f8dce2eb28d7371e900862e5a96be492739167f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/forward-command-controller/default.nix
+++ b/distros/jazzy/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-forward-command-controller";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/forward_command_controller/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "253d7b0b593c4a8166bea4ce823ebd333b3b8a22fc2e04607292b852d5c6154a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/forward_command_controller/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "f54bf5c63cbbf1cafa674dc5bff65987964f068028268474a760e7451bcd7d72";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -162,11 +162,19 @@ self: super: {
 
  apriltag-detector = self.callPackage ./apriltag-detector {};
 
+ apriltag-detector-mit = self.callPackage ./apriltag-detector-mit {};
+
+ apriltag-detector-umich = self.callPackage ./apriltag-detector-umich {};
+
+ apriltag-draw = self.callPackage ./apriltag-draw {};
+
  apriltag-mit = self.callPackage ./apriltag-mit {};
 
  apriltag-msgs = self.callPackage ./apriltag-msgs {};
 
  apriltag-ros = self.callPackage ./apriltag-ros {};
+
+ apriltag-tools = self.callPackage ./apriltag-tools {};
 
  aruco = self.callPackage ./aruco {};
 
@@ -371,6 +379,8 @@ self: super: {
  clearpath-platform-msgs = self.callPackage ./clearpath-platform-msgs {};
 
  clearpath-ros2-socketcan-interface = self.callPackage ./clearpath-ros2-socketcan-interface {};
+
+ clearpath-sensors-description = self.callPackage ./clearpath-sensors-description {};
 
  clearpath-viz = self.callPackage ./clearpath-viz {};
 
@@ -2146,6 +2156,8 @@ self: super: {
 
  rmw-dds-common = self.callPackage ./rmw-dds-common {};
 
+ rmw-desert = self.callPackage ./rmw-desert {};
+
  rmw-fastrtps-cpp = self.callPackage ./rmw-fastrtps-cpp {};
 
  rmw-fastrtps-dynamic-cpp = self.callPackage ./rmw-fastrtps-dynamic-cpp {};
@@ -2961,6 +2973,8 @@ self: super: {
  velocity-controllers = self.callPackage ./velocity-controllers {};
 
  velodyne = self.callPackage ./velodyne {};
+
+ velodyne-description = self.callPackage ./velodyne-description {};
 
  velodyne-driver = self.callPackage ./velodyne-driver {};
 

--- a/distros/jazzy/gpio-controllers/default.nix
+++ b/distros/jazzy/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-gpio-controllers";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gpio_controllers/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "8c81b5dc43a0b7ff3fbe23e2376dc70e853bea394ab5bd6c8ac62a80eac1c5c2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gpio_controllers/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "747e6425380f86879e60c6d1cc5c970c99f344181c5fb18d07dac2ebcb1cf335";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gripper-controllers/default.nix
+++ b/distros/jazzy/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-gripper-controllers";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gripper_controllers/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "ab0f146225b676ae11afbfd38e2aa10203f30f60b9e7c765ed0149be8ee8cb57";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gripper_controllers/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "e4bd3d86965eb8ce5813cf61f9e0aa0df853acb9f73baf3a1c2ea214496269dd";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/hardware-interface-testing/default.nix
+++ b/distros/jazzy/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-hardware-interface-testing";
-  version = "4.26.0-r1";
+  version = "4.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface_testing/4.26.0-1.tar.gz";
-    name = "4.26.0-1.tar.gz";
-    sha256 = "d07b10bc9f5b1187b4c2d9c326ba9fbf30f43a4ac47be8e780b1c7c352d28645";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface_testing/4.27.0-1.tar.gz";
+    name = "4.27.0-1.tar.gz";
+    sha256 = "c556d8fe1cf91dd9d2da9d83916f03a1f2f1b9f1447c64ed37af0a7c2c14f5ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/hardware-interface/default.nix
+++ b/distros/jazzy/hardware-interface/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, control-msgs, joint-limits, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, realtime-tools, ros2-control-test-assets, sdformat-urdf, tinyxml2-vendor, urdf }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, control-msgs, joint-limits, lifecycle-msgs, pal-statistics, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, realtime-tools, ros2-control-test-assets, sdformat-urdf, tinyxml2-vendor, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-hardware-interface";
-  version = "4.26.0-r1";
+  version = "4.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface/4.26.0-1.tar.gz";
-    name = "4.26.0-1.tar.gz";
-    sha256 = "eb00240a98313ce30d8f13da156feb9d023f00d973c3ae3f16bf302fba502e47";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface/4.27.0-1.tar.gz";
+    name = "4.27.0-1.tar.gz";
+    sha256 = "ff0e0ebcb5232645948b8a1bb95782630fd300443af5254afa47ee60d9e76b66";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gen-version-h ];
   checkInputs = [ ament-cmake-gmock ros2-control-test-assets ];
-  propagatedBuildInputs = [ backward-ros control-msgs joint-limits lifecycle-msgs pluginlib rclcpp-lifecycle rcpputils rcutils realtime-tools sdformat-urdf tinyxml2-vendor urdf ];
+  propagatedBuildInputs = [ backward-ros control-msgs joint-limits lifecycle-msgs pal-statistics pluginlib rclcpp-lifecycle rcpputils rcutils realtime-tools sdformat-urdf tinyxml2-vendor urdf ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ];
 
   meta = {

--- a/distros/jazzy/image-pipeline/default.nix
+++ b/distros/jazzy/image-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, camera-calibration, depth-image-proc, image-proc, image-publisher, image-rotate, image-view, stereo-image-proc }:
 buildRosPackage {
   pname = "ros-jazzy-image-pipeline";
-  version = "5.0.8-r1";
+  version = "5.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/image_pipeline/5.0.8-1.tar.gz";
-    name = "5.0.8-1.tar.gz";
-    sha256 = "eb9fa3b2e0b1ea2b65222f7f70e267b9e804a620dd3e0b14b426081595a6db89";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/image_pipeline/5.0.9-1.tar.gz";
+    name = "5.0.9-1.tar.gz";
+    sha256 = "5b79fce8f998f13fae1e545ae51f20f6607e0ac0d51367ae2a72f007182ea156";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/image-proc/default.nix
+++ b/distros/jazzy/image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, camera-calibration-parsers, cv-bridge, geometry-msgs, image-geometry, image-transport, opencv, rclcpp, rclcpp-components, rcutils, sensor-msgs, tf2, tf2-geometry-msgs, tracetools-image-pipeline }:
 buildRosPackage {
   pname = "ros-jazzy-image-proc";
-  version = "5.0.8-r1";
+  version = "5.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/image_proc/5.0.8-1.tar.gz";
-    name = "5.0.8-1.tar.gz";
-    sha256 = "42e714625e85e64def0be3e7cfca032f75e4aec5f48f6c8eb9147af9d88cd775";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/image_proc/5.0.9-1.tar.gz";
+    name = "5.0.9-1.tar.gz";
+    sha256 = "191ca2ff02d21bff2b2ca7765efa007d53341d6347208e5146a662f99d06894d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/image-publisher/default.nix
+++ b/distros/jazzy/image-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, camera-info-manager, cv-bridge, image-transport, rcl-interfaces, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-jazzy-image-publisher";
-  version = "5.0.8-r1";
+  version = "5.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/image_publisher/5.0.8-1.tar.gz";
-    name = "5.0.8-1.tar.gz";
-    sha256 = "30b4b5a48a8bfb80570c3da8798c0be179920db16a0e7b60be54e3502e5dcf35";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/image_publisher/5.0.9-1.tar.gz";
+    name = "5.0.9-1.tar.gz";
+    sha256 = "147e87cce44b926fc39e2c7bc2da6dc97eebbfbe7102a81b473b3c499dcdd930";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/image-rotate/default.nix
+++ b/distros/jazzy/image-rotate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, class-loader, cv-bridge, geometry-msgs, image-transport, opencv, rcl-interfaces, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-image-rotate";
-  version = "5.0.8-r1";
+  version = "5.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/image_rotate/5.0.8-1.tar.gz";
-    name = "5.0.8-1.tar.gz";
-    sha256 = "a56960a6b168f43ffa370f33b9318a3287f7ddb0de8021da97311aafa4796f67";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/image_rotate/5.0.9-1.tar.gz";
+    name = "5.0.9-1.tar.gz";
+    sha256 = "8d4d5a7b87530ffd9cc75a39379aa0d300a15cf8658b8540d7b9ccc10651abc8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/image-view/default.nix
+++ b/distros/jazzy/image-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, camera-calibration-parsers, cv-bridge, image-transport, message-filters, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-srvs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-image-view";
-  version = "5.0.8-r1";
+  version = "5.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/image_view/5.0.8-1.tar.gz";
-    name = "5.0.8-1.tar.gz";
-    sha256 = "97ce9e575d8a8230c7b093fe275d198eb9b5aee1040a99a6db40dfe42400e7a2";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/image_view/5.0.9-1.tar.gz";
+    name = "5.0.9-1.tar.gz";
+    sha256 = "e696767b9a833c90ea0a3ada8d4fdde9b7e1a4a012a8d0c8d0835c471a088233";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/imu-sensor-broadcaster/default.nix
+++ b/distros/jazzy/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-imu-sensor-broadcaster";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/imu_sensor_broadcaster/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "de1fe9e0abc7b68034d36d33e92439a21f9f918c308a349f2a1b6cf295481125";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/imu_sensor_broadcaster/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "aa97158015e88f93e9b19ab59d0a356d53822ab153c56747703f3d4025815e0b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/joint-limits/default.nix
+++ b/distros/jazzy/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-gtest, backward-ros, generate-parameter-library, launch-ros, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-limits";
-  version = "4.26.0-r1";
+  version = "4.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/joint_limits/4.26.0-1.tar.gz";
-    name = "4.26.0-1.tar.gz";
-    sha256 = "5bd6c50dc26858a4eafd581cf9829bf748448aff72d988fd18c0be757c093207";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/joint_limits/4.27.0-1.tar.gz";
+    name = "4.27.0-1.tar.gz";
+    sha256 = "d3371c06f30844b20e308311c86bc9781d824a327aaaa106ccd09ebf704f264c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/joint-state-broadcaster/default.nix
+++ b/distros/jazzy/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-state-broadcaster";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_state_broadcaster/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "c99fe38b630d440c42977cdc236146cb2c4c9bcd876f1c67f73a6ba3f65d7846";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_state_broadcaster/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "dc43a86a6df7c15762b5b9e1ccbfe52def740a2c7e40467c2316097744ac4ac0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/joint-trajectory-controller/default.nix
+++ b/distros/jazzy/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-trajectory-controller";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_trajectory_controller/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "f35466e9526b39135df5ba5bd93a917afa731c4a8b62cd07e5dd423ad62aed89";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_trajectory_controller/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "f6d2ef7b56ecde0cbf1d41e4d6836ede7e70feff820661e06f158ef66e83fe7a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mecanum-drive-controller/default.nix
+++ b/distros/jazzy/mecanum-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mecanum-drive-controller";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/mecanum_drive_controller/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "0341deb6314f9f1a349f2aa4c555ed603f4810e34e2374bad6f1145368bea38d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/mecanum_drive_controller/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "72c8d5e378064bf9e79d1ceebf1c45f75870e7e165a9f959b3d82c54e50f8f70";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/parallel-gripper-controller/default.nix
+++ b/distros/jazzy/parallel-gripper-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-parallel-gripper-controller";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/parallel_gripper_controller/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "c6d1500c2c97f02816dea981510664a79c78e693c5046a40db692470d952ec11";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/parallel_gripper_controller/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "9bcdaeafe9a05943b9691d178f135d7eb95c118f69db95bd9e7d5761ee5c51e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pid-controller/default.nix
+++ b/distros/jazzy/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-pid-controller";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pid_controller/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "323987e7b25156288c108814540206882353320dad488bb569751f223dd4cfb0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pid_controller/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "547c2cae6444feef19c02e9fc21e7aa7315a3b67e69eafa9e5d61a453145d61c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pose-broadcaster/default.nix
+++ b/distros/jazzy/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-pose-broadcaster";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pose_broadcaster/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "43cfed37ef2b9d97533aed8ae91880b36757ba4b6330ea998181a91cd91feec2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pose_broadcaster/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "9ff302d6d805b0bec0588ae30c4dbeeca3fe473c1304c1738e28b8dbb46faf90";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/position-controllers/default.nix
+++ b/distros/jazzy/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-position-controllers";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/position_controllers/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "e4cdd4ce9c34aecf1ea6d4c231c67e0d67c74fe9d2719dd5653abd941879c850";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/position_controllers/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "78ea27f0a0129435169b633f34bb37c6dc308a4a5c1e48fdd2799302b36ba4a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/range-sensor-broadcaster/default.nix
+++ b/distros/jazzy/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-range-sensor-broadcaster";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/range_sensor_broadcaster/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "225636f017cd35d500c75394be5ad5112268f7b8fb6271bf5c6cc0637ee00e61";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/range_sensor_broadcaster/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "7a529632046eaf01de11fd8a7f649872368f057d3bf48ab568c064ebc20106ed";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rmw-desert/default.nix
+++ b/distros/jazzy/rmw-desert/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-cmake, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
+buildRosPackage {
+  pname = "ros-jazzy-rmw-desert";
+  version = "1.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmw_desert-release/archive/release/jazzy/rmw_desert/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "e88105a88eab0efe732ad4d9a587a26e6ceb46be0a9e59c705dbee46f8ff3f73";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  propagatedBuildInputs = [ ament-cmake rcpputils rcutils rmw rmw-dds-common rosidl-cmake rosidl-runtime-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros rosidl-cmake ];
+
+  meta = {
+    description = "Implement the ROS middleware interface using the DESERT protocol stack for underwater communications.";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/jazzy/ros2-control-test-assets/default.nix
+++ b/distros/jazzy/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-control-test-assets";
-  version = "4.26.0-r1";
+  version = "4.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control_test_assets/4.26.0-1.tar.gz";
-    name = "4.26.0-1.tar.gz";
-    sha256 = "45970422b25f2ebc8c3433560fa88c9de4d193989f5a453cf8e497ecd39d9bf0";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control_test_assets/4.27.0-1.tar.gz";
+    name = "4.27.0-1.tar.gz";
+    sha256 = "b82601e88d15ad1670510778212914c8b7512a9eabc1b2fb06dddcdf0e969ded";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-control/default.nix
+++ b/distros/jazzy/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-control";
-  version = "4.26.0-r1";
+  version = "4.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control/4.26.0-1.tar.gz";
-    name = "4.26.0-1.tar.gz";
-    sha256 = "e16bbf09a6aeec314906878f6610c468994e3fda96d1f208fc09aba5beb6e810";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control/4.27.0-1.tar.gz";
+    name = "4.27.0-1.tar.gz";
+    sha256 = "71c99c26dbca64b13af5a68be4900f46af3c56cb87d0427a2c7b4ed0f2289d39";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-controllers-test-nodes/default.nix
+++ b/distros/jazzy/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-controllers-test-nodes";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers_test_nodes/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "889d3e00cc550086c3a7afe6fc2e9ce7bd96598787a13f0a05131da699f7808f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers_test_nodes/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "e8ef45c7582979b2f1d20b60be5e1a04ca9943bf7c7103f3f9f071510faa5bff";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2-controllers/default.nix
+++ b/distros/jazzy/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gripper-controllers, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, parallel-gripper-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-controllers";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "2582290be92b02e42c9611636017d39bf67940bb13708c4afd4097322247060d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "e4baf5c08e9e8cab65b14d31e138d010348cf980834495154e5d2fb760dd735a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2controlcli/default.nix
+++ b/distros/jazzy/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-jazzy-ros2controlcli";
-  version = "4.26.0-r1";
+  version = "4.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2controlcli/4.26.0-1.tar.gz";
-    name = "4.26.0-1.tar.gz";
-    sha256 = "f2550237b140297370299bed658728533337c4a32050d094ed7ceb41f2746eb9";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2controlcli/4.27.0-1.tar.gz";
+    name = "4.27.0-1.tar.gz";
+    sha256 = "54c2087c3edbbff0874b311fafe75fd28d7d3e98e1a84d6d5ece3ffcd69bc963";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rqt-controller-manager/default.nix
+++ b/distros/jazzy/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-jazzy-rqt-controller-manager";
-  version = "4.26.0-r1";
+  version = "4.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/rqt_controller_manager/4.26.0-1.tar.gz";
-    name = "4.26.0-1.tar.gz";
-    sha256 = "456d10d404ed791d4a0d1829615d9ca23422f273660fa6d15a454351825f8f62";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/rqt_controller_manager/4.27.0-1.tar.gz";
+    name = "4.27.0-1.tar.gz";
+    sha256 = "ce75bc86d1f1e3f38ac0a348c5b4c255932e6a74f4f063e718f7e379ededf960";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rqt-joint-trajectory-controller/default.nix
+++ b/distros/jazzy/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rqt-joint-trajectory-controller";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/rqt_joint_trajectory_controller/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "a74be614c697e92f52a5ae5f20d25a5b8694e9c73e6a3422d4132439e81c2e18";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/rqt_joint_trajectory_controller/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "e112ffd8cbf13b1ef235d83f21629764f70e364e91f567df4b0588583ca08141";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rviz-satellite/default.nix
+++ b/distros/jazzy/rviz-satellite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, qt5, rclcpp, rcpputils, rviz-common, rviz-default-plugins, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-satellite";
-  version = "4.1.0-r1";
+  version = "4.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/rviz_satellite-release/archive/release/jazzy/rviz_satellite/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "dacfd0a51db37aacd1aa3b950688d3eb1255e8196550b868c300fd9398068b87";
+    url = "https://github.com/nobleo/rviz_satellite-release/archive/release/jazzy/rviz_satellite/4.1.0-2.tar.gz";
+    name = "4.1.0-2.tar.gz";
+    sha256 = "789a402211be3570861b89386ab025a948f4a900eb435c5438ad374a9c3bc4d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/steering-controllers-library/default.nix
+++ b/distros/jazzy/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-steering-controllers-library";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/steering_controllers_library/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "8d1f1a62294e8a29fa6efadebd12cfdcdabda956aab883f88e0f45052a4e8da9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/steering_controllers_library/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "28d1f03000974cb5e38223c062c830ccca0ecd9307dcf30fea741bc146fce578";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/stereo-image-proc/default.nix
+++ b/distros/jazzy/stereo-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-geometry, image-proc, image-transport, launch, launch-ros, launch-testing, launch-testing-ament-cmake, message-filters, python-cmake-module, python3Packages, rclcpp, rclcpp-components, rclpy, ros-testing, sensor-msgs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-stereo-image-proc";
-  version = "5.0.8-r1";
+  version = "5.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/stereo_image_proc/5.0.8-1.tar.gz";
-    name = "5.0.8-1.tar.gz";
-    sha256 = "f70aebeda667115fad5a2aed7490b4ad2475bb9501b3923cac1ee06741ff59f7";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/stereo_image_proc/5.0.9-1.tar.gz";
+    name = "5.0.9-1.tar.gz";
+    sha256 = "083d01447c788973b6f6c72a56f3bf4986e79cfe01743a50626ce32690adce25";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tracetools-image-pipeline/default.nix
+++ b/distros/jazzy/tracetools-image-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, pkg-config }:
 buildRosPackage {
   pname = "ros-jazzy-tracetools-image-pipeline";
-  version = "5.0.8-r1";
+  version = "5.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/tracetools_image_pipeline/5.0.8-1.tar.gz";
-    name = "5.0.8-1.tar.gz";
-    sha256 = "d0d82e89d3456915efad8b73a79718c2649ba3251099eeaabeefa07bc9ecaff8";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/tracetools_image_pipeline/5.0.9-1.tar.gz";
+    name = "5.0.9-1.tar.gz";
+    sha256 = "a464a280fe56819f312dbaec2a6ea59249afc3b1f644c5b02827ef60fb25d39f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/transmission-interface/default.nix
+++ b/distros/jazzy/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, hardware-interface, pluginlib, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-transmission-interface";
-  version = "4.26.0-r1";
+  version = "4.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/transmission_interface/4.26.0-1.tar.gz";
-    name = "4.26.0-1.tar.gz";
-    sha256 = "815c5055e3221d85849a4c7ccd7144a780a7a2da68d89f8fe45dfdbaf7438cd7";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/transmission_interface/4.27.0-1.tar.gz";
+    name = "4.27.0-1.tar.gz";
+    sha256 = "29375a255e1fd246813a5e11220f498d9d8cf498b530820a18ad09c24ba24a3f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tricycle-controller/default.nix
+++ b/distros/jazzy/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-tricycle-controller";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_controller/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "2a19e7fc0d6bb337e3fbf1ef77323fd9cad3546631e5e2df533a486e12c2f896";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_controller/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "efff6f3b5d6db7b25211354aca73a1c219b573fac689668a442865e31c63ca95";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tricycle-steering-controller/default.nix
+++ b/distros/jazzy/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-tricycle-steering-controller";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_steering_controller/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "07cb25d00a182302e82907fa8d410ab35a23089c31174fe35b0c90e4da210658";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_steering_controller/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "2fda1c6ea3c5d8448cec3f08c324e0e6713c3770e5041cd962b4ffbf98604405";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/turtlebot4-setup/default.nix
+++ b/distros/jazzy/turtlebot4-setup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, chrony, curl, networkmanager, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, robot-upstart, simple-term-menu-vendor, socat }:
 buildRosPackage {
   pname = "ros-jazzy-turtlebot4-setup";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4_setup-release/archive/release/jazzy/turtlebot4_setup/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "76a21937b5f8a4b82f11b8b54b12bc9ee6e1fea965072f44999ea3ce2d7ff70f";
+    url = "https://github.com/ros2-gbp/turtlebot4_setup-release/archive/release/jazzy/turtlebot4_setup/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "8b512cf0da6bf2388c9e0885506c5c8f5cc5b084909709cb6964575e92a1d83a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-calibration/default.nix
+++ b/distros/jazzy/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-ur-calibration";
-  version = "3.0.2-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_calibration/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "e352fea0747dc0654e91d15fb17df18a7ef77e1f98e9a7415fdb25ac13bc2ab9";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_calibration/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "2f223f0ba88f76488163089b36f6256ec796a4c18457c7497d01fa485bddb25a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-controllers/default.nix
+++ b/distros/jazzy/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, angles, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, trajectory-msgs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ur-controllers";
-  version = "3.0.2-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_controllers/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "6ef9ba6e5304555ccb8aedc9e900ec859c0096664f39e146db83f5e100801029";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_controllers/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "c38f638ec227eeca9400bd6527d4a147f8519231405e0c52cc368d6fc8488046";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-dashboard-msgs/default.nix
+++ b/distros/jazzy/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-ur-dashboard-msgs";
-  version = "3.0.2-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_dashboard_msgs/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "fa0af8c54bf70d64286d19f83a47270f78bfa145bce8118ebfd5fba25c05f5ad";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_dashboard_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "a64eed0e5b724c753f0d629798ec09b283e75d3110b58694ce18d58322936e47";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-moveit-config/default.nix
+++ b/distros/jazzy/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, ur-description, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-ur-moveit-config";
-  version = "3.0.2-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_moveit_config/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "9c8108b363dadf2f75c25cb2fd6d056943241b0b23574a3f18f9dc77403afe32";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_moveit_config/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "3fc426a8e90cc80b430d68a21018eae1394a629a36b1b6b4c0c629c867815ebc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-robot-driver/default.nix
+++ b/distros/jazzy/ur-robot-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, backward-ros, controller-manager, controller-manager-msgs, force-torque-sensor-broadcaster, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, pluginlib, pose-broadcaster, position-controllers, rclcpp, rclcpp-lifecycle, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, socat, std-msgs, std-srvs, tf2-geometry-msgs, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-ur-robot-driver";
-  version = "3.0.2-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_robot_driver/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "3aa5baeb2da47ef99656b6b0f81d152d226fa122c62fc67ba690e3d98ada0304";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_robot_driver/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "e8e6da6d088c66091e3b52f63905f6e8a5b50abea981d9bb963d04218cbb4691";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur/default.nix
+++ b/distros/jazzy/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-jazzy-ur";
-  version = "3.0.2-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "de1537866c18a31aa527e3b646c25494fa4b50b43fc4769c9b4d90d348d31de0";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "2db548bf9fd33ff51abf58ba9838280fb4b6eead8b1820bee12e23e8f2b67a43";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/velocity-controllers/default.nix
+++ b/distros/jazzy/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-velocity-controllers";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/velocity_controllers/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "45093d6e109c40af64be97a673aceaa49dda5d645200acad998a591606e2f087";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/velocity_controllers/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "ea445bc6c7a8a6eb79420423bc915445987bacd07876d1e56e5a3aa4358ededf";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/velodyne-description/default.nix
+++ b/distros/jazzy/velodyne-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-velodyne-description";
-  version = "2.0.3-r4";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/velodyne_simulator-release/archive/release/jazzy/velodyne_description/2.0.3-4.tar.gz";
-    name = "2.0.3-4.tar.gz";
-    sha256 = "def546ec18a95fdbfa0e101469390072898dedc0ef2187cfc394dc73f4e7db42";
+    url = "https://github.com/ros2-gbp/velodyne_simulator-release/archive/release/jazzy/velodyne_description/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "54ba661f653172f5182ae560f4a298ca735851fde4c9c030196efb3cb1497a4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/wireless-msgs/default.nix
+++ b/distros/jazzy/wireless-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-wireless-msgs";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/wireless-release/archive/release/jazzy/wireless_msgs/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "a07a7ae799604632b9958109c59b3fa154b53d0f8f5e0a645b6e8ae25e3962ea";
+    url = "https://github.com/clearpath-gbp/wireless-release/archive/release/jazzy/wireless_msgs/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "77f77397cca6414d70666eab1b05ba8ffd94a203c62f8ab50ec370f2e3e3e1bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/wireless-watcher/default.nix
+++ b/distros/jazzy/wireless-watcher/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, rclcpp, wireless-msgs, wirelesstools }:
+{ lib, buildRosPackage, fetchurl, diagnostic-updater, rclcpp, wireless-msgs, wirelesstools }:
 buildRosPackage {
   pname = "ros-jazzy-wireless-watcher";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/wireless-release/archive/release/jazzy/wireless_watcher/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "90efeab7955fb141ad2edcfea6ed1bab914885c28fa7bde48b03ad2cc1f13fcb";
+    url = "https://github.com/clearpath-gbp/wireless-release/archive/release/jazzy/wireless_watcher/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "a4fe28d7c6ef1f909182f99f37b7d66e2cc48ae8cc73555e0b79661e7a7d2b0d";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ rclcpp wireless-msgs wirelesstools ];
+  propagatedBuildInputs = [ diagnostic-updater rclcpp wireless-msgs wirelesstools ];
 
   meta = {
     description = "A node which publishes connection information about a linux wireless interface.";

--- a/distros/rolling/ackermann-steering-controller/default.nix
+++ b/distros/rolling/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-ackermann-steering-controller";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "90c17ef59dd9eb185916d5e0879c2183f5895a7407edb2f25c7402485b7faa93";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "fb927854fd3d04a77f92610cbbb837aafaddd29e35cd4f4f0e8343fba9a2b4dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/admittance-controller/default.nix
+++ b/distros/rolling/admittance-controller/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-admittance-controller";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "aafc1338148ae81551ae2ba83cbdf17bd399d28643008623deb42905f01cec0a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "300fde300b5e5122a6ff217a4ae7fc9dd6ce4a189fb895f633c2392972e3b4e4";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing kinematics-interface-kdl ros2-control-test-assets ];
-  propagatedBuildInputs = [ backward-ros control-msgs control-toolbox controller-interface filters generate-parameter-library geometry-msgs hardware-interface joint-trajectory-controller kinematics-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools tf2 tf2-eigen tf2-geometry-msgs tf2-kdl tf2-ros trajectory-msgs ];
+  propagatedBuildInputs = [ angles backward-ros control-msgs control-toolbox controller-interface generate-parameter-library geometry-msgs hardware-interface kinematics-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools tf2 tf2-eigen tf2-geometry-msgs tf2-kdl tf2-ros trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/apriltag-detector-mit/default.nix
+++ b/distros/rolling/apriltag-detector-mit/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, apriltag-detector, apriltag-mit, apriltag-msgs, cv-bridge, image-transport, pluginlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, apriltag-detector, apriltag-mit, apriltag-msgs, pluginlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-apriltag-detector-mit";
-  version = "2.0.0-r1";
+  version = "3.0.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/rolling/apriltag_detector_mit/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "f555792b916f4f83ae6a3c11e8691b3004ba80ac6cbf8d851813d8041ab4d65b";
+    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/rolling/apriltag_detector_mit/3.0.1-2.tar.gz";
+    name = "3.0.1-2.tar.gz";
+    sha256 = "5aec0f4e53906d46f51aa433e994dfc8cfaf0232c2bdff7c46b1411aea627928";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ros-environment ];
   checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ apriltag-detector apriltag-mit apriltag-msgs cv-bridge image-transport pluginlib rclcpp rclcpp-components sensor-msgs ];
+  propagatedBuildInputs = [ apriltag-detector apriltag-mit apriltag-msgs pluginlib rclcpp rclcpp-components sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ros-environment ];
 
   meta = {

--- a/distros/rolling/apriltag-detector-umich/default.nix
+++ b/distros/rolling/apriltag-detector-umich/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, apriltag, apriltag-detector, apriltag-msgs, cv-bridge, image-transport, pluginlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, apriltag, apriltag-detector, apriltag-msgs, opencv, pluginlib, rclcpp, ros-environment, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-apriltag-detector-umich";
-  version = "2.0.0-r1";
+  version = "3.0.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/rolling/apriltag_detector_umich/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "9d17a1d2c16fc5bfa5965cacc3a9eb6bf57d0bc6e427958a4c5033dfdacab84a";
+    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/rolling/apriltag_detector_umich/3.0.1-2.tar.gz";
+    name = "3.0.1-2.tar.gz";
+    sha256 = "c754609a275cf68273534f290165ec3cbbd80b859d4c1fc09d4002f6932bfdf4";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ros-environment ];
   checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ apriltag apriltag-detector apriltag-msgs cv-bridge image-transport pluginlib rclcpp rclcpp-components sensor-msgs ];
+  propagatedBuildInputs = [ apriltag apriltag-detector apriltag-msgs opencv opencv.cxxdev pluginlib rclcpp sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ros-environment ];
 
   meta = {

--- a/distros/rolling/apriltag-detector/default.nix
+++ b/distros/rolling/apriltag-detector/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, apriltag-msgs, pluginlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, apriltag-msgs, cv-bridge, image-transport, pluginlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-apriltag-detector";
-  version = "2.0.0-r1";
+  version = "3.0.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/rolling/apriltag_detector/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "619b860bcdb2627dae32eecc664d2b49c5ee153290ba279af8112fc41617b87c";
+    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/rolling/apriltag_detector/3.0.1-2.tar.gz";
+    name = "3.0.1-2.tar.gz";
+    sha256 = "bcf71f2f8028113693f11eddda41fe2c8184ac7e533e542e470e26e6f3118bea";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ros-environment ];
+  buildInputs = [ ament-cmake ros-environment ];
   checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ apriltag-msgs pluginlib rclcpp rclcpp-components sensor-msgs ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ros-environment ];
+  propagatedBuildInputs = [ apriltag-msgs cv-bridge image-transport pluginlib rclcpp rclcpp-components sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ros-environment ];
 
   meta = {
     description = "ROS2 package for apriltag detection";

--- a/distros/rolling/apriltag-draw/default.nix
+++ b/distros/rolling/apriltag-draw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, apriltag-msgs, cv-bridge, image-transport, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-apriltag-draw";
-  version = "2.0.0-r1";
+  version = "3.0.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/rolling/apriltag_draw/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "83da4283f6002bb05bcdccf0b5d4f890c432513b9e75b87f6b8acc91bfe717ab";
+    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/rolling/apriltag_draw/3.0.1-2.tar.gz";
+    name = "3.0.1-2.tar.gz";
+    sha256 = "042b12174bbaedbe06e56e09094eb2477d28ea396e4b9d7137d24c7d57b8108c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/apriltag-tools/default.nix
+++ b/distros/rolling/apriltag-tools/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, apriltag-detector, apriltag-draw, apriltag-msgs, rclcpp, ros-environment, rosbag2-transport }:
+buildRosPackage {
+  pname = "ros-rolling-apriltag-tools";
+  version = "3.0.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/rolling/apriltag_tools/3.0.1-2.tar.gz";
+    name = "3.0.1-2.tar.gz";
+    sha256 = "a190163081e6ad44d9df25eb4b74a6ff9b782f38f561e0aa656aa085984be066";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment ];
+  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ apriltag-detector apriltag-draw apriltag-msgs rclcpp rosbag2-transport ];
+  nativeBuildInputs = [ ament-cmake ros-environment ];
+
+  meta = {
+    description = "misc tools for working with apriltags under ROS2";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/bicycle-steering-controller/default.nix
+++ b/distros/rolling/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-bicycle-steering-controller";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "4b69ab6d5628e1150265d045953158b80a56749a155666afb3b4020d9dbc609b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "736309d5113b1fad8be53a298593675d10be8b0d1527c86b25b64498792f4016";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-interface/default.nix
+++ b/distros/rolling/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, geometry-msgs, hardware-interface, rclcpp-lifecycle, realtime-tools, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-interface";
-  version = "4.26.0-r1";
+  version = "4.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/4.26.0-1.tar.gz";
-    name = "4.26.0-1.tar.gz";
-    sha256 = "31b877ff326979e33259cd4db6ac9c60bfb4eb1b3a1ba9f603b1b7eccb0365c8";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/4.27.0-1.tar.gz";
+    name = "4.27.0-1.tar.gz";
+    sha256 = "950e2644c404a63a0f4273d651a4e9e034eccee5cb2cd8a270012c230c9beb97";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager-msgs/default.nix
+++ b/distros/rolling/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager-msgs";
-  version = "4.26.0-r1";
+  version = "4.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/4.26.0-1.tar.gz";
-    name = "4.26.0-1.tar.gz";
-    sha256 = "ef1f32edf7f9eda942262aaca95b13b8491aa91dbf7c27087dfd8d5907d3806c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/4.27.0-1.tar.gz";
+    name = "4.27.0-1.tar.gz";
+    sha256 = "299ecbf784fc57ee9c3aad20428ab3317c410b569ece6a91e52c35926c71eae4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager/default.nix
+++ b/distros/rolling/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, example-interfaces, generate-parameter-library, hardware-interface, hardware-interface-testing, launch, launch-ros, launch-testing, launch-testing-ros, libstatistics-collector, pluginlib, python3Packages, rclcpp, rclpy, rcpputils, realtime-tools, robot-state-publisher, ros2-control-test-assets, ros2param, ros2run, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager";
-  version = "4.26.0-r1";
+  version = "4.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/4.26.0-1.tar.gz";
-    name = "4.26.0-1.tar.gz";
-    sha256 = "c11e88551bff67fa8390fdd134c912ddec37341932b134b3d0ec32ddfd430678";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/4.27.0-1.tar.gz";
+    name = "4.27.0-1.tar.gz";
+    sha256 = "f56ba16948df139738a2852ef604f31b9efb8a4afeee404eb6ed444929269030";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/diff-drive-controller/default.nix
+++ b/distros/rolling/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diff-drive-controller";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "2df8ac5355738d28c631522fcbb07461fe6f2f46c82c70bfc0e04fb7dff93024";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "2511b7cd69922996c4e1baeb81051a8a2c955e31516e2a1040f2ecc6d99cbd65";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/effort-controllers/default.nix
+++ b/distros/rolling/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-effort-controllers";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "2b57713715a63ed54849c90b9c1613c402b78f138f45e8685bc50bb01b752bcc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "f2674ce03a7b901f82e702fe193ea829bd0824fc33f5f2d7f806c8a16679a91e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fastdds/default.nix
+++ b/distros/rolling/fastdds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, python3, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-rolling-fastdds";
-  version = "3.1.2-r1";
+  version = "3.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastdds-release/archive/release/rolling/fastdds/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "167c2dca35012b69b5124d1ddc1eeb5a3362899d7d78ba970af9380959a4ff34";
+    url = "https://github.com/ros2-gbp/fastdds-release/archive/release/rolling/fastdds/3.1.2-2.tar.gz";
+    name = "3.1.2-2.tar.gz";
+    sha256 = "8f46286dab603522faf269c68fe7ad11d2a2ff768feb3a816e548387ce603028";
   };
 
   buildType = "cmake";

--- a/distros/rolling/force-torque-sensor-broadcaster/default.nix
+++ b/distros/rolling/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-force-torque-sensor-broadcaster";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "f79c90a32f186bd94ff67f8329283d72f3cefbd4dc2fb6aba354c7c423a41e37";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "9db4831477e538cab74fc4846aa09b61b9a1f203c672e2eee8c15de241219ba6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/forward-command-controller/default.nix
+++ b/distros/rolling/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-forward-command-controller";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "a38ae8e65c7e2297a229dc63b12584e972b3cd0b309bb5f6757834a1bb3ebae6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "8af0fb26f57896845ceaab39bff6d50695c964256541fcde6405d3298a192a81";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -172,6 +172,8 @@ self: super: {
 
  apriltag-ros = self.callPackage ./apriltag-ros {};
 
+ apriltag-tools = self.callPackage ./apriltag-tools {};
+
  aruco = self.callPackage ./aruco {};
 
  aruco-msgs = self.callPackage ./aruco-msgs {};
@@ -587,8 +589,6 @@ self: super: {
  fastcdr = self.callPackage ./fastcdr {};
 
  fastdds = self.callPackage ./fastdds {};
-
- fastrtps-cmake-module = self.callPackage ./fastrtps-cmake-module {};
 
  ffmpeg-encoder-decoder = self.callPackage ./ffmpeg-encoder-decoder {};
 
@@ -1776,6 +1776,12 @@ self: super: {
 
  rmw-desert = self.callPackage ./rmw-desert {};
 
+ rmw-fastrtps-cpp = self.callPackage ./rmw-fastrtps-cpp {};
+
+ rmw-fastrtps-dynamic-cpp = self.callPackage ./rmw-fastrtps-dynamic-cpp {};
+
+ rmw-fastrtps-shared-cpp = self.callPackage ./rmw-fastrtps-shared-cpp {};
+
  rmw-implementation = self.callPackage ./rmw-implementation {};
 
  rmw-implementation-cmake = self.callPackage ./rmw-implementation-cmake {};
@@ -1962,6 +1968,8 @@ self: super: {
 
  rosidl-dynamic-typesupport = self.callPackage ./rosidl-dynamic-typesupport {};
 
+ rosidl-dynamic-typesupport-fastrtps = self.callPackage ./rosidl-dynamic-typesupport-fastrtps {};
+
  rosidl-generator-c = self.callPackage ./rosidl-generator-c {};
 
  rosidl-generator-cpp = self.callPackage ./rosidl-generator-cpp {};
@@ -1985,10 +1993,6 @@ self: super: {
  rosidl-typesupport-c = self.callPackage ./rosidl-typesupport-c {};
 
  rosidl-typesupport-cpp = self.callPackage ./rosidl-typesupport-cpp {};
-
- rosidl-typesupport-fastrtps-c = self.callPackage ./rosidl-typesupport-fastrtps-c {};
-
- rosidl-typesupport-fastrtps-cpp = self.callPackage ./rosidl-typesupport-fastrtps-cpp {};
 
  rosidl-typesupport-interface = self.callPackage ./rosidl-typesupport-interface {};
 

--- a/distros/rolling/gpio-controllers/default.nix
+++ b/distros/rolling/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-gpio-controllers";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gpio_controllers/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "ef8de78bb28f01a12ca9667ffd7b2d0a989d2baf5204cd7f224b37b1e7906cf2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gpio_controllers/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "21764351a13df4728eaad39cf05bab958eeb64ba4ad3e035d9c96d522bbf4758";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gripper-controllers/default.nix
+++ b/distros/rolling/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-gripper-controllers";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "3f177131d0668cd00136a5d1c845242b2ff41f3a5c865c626d9aef9adc3fa518";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "3b3ceaec706f21f22254a64ddff18910dd4055626b5b3fe9024ebea92134dee0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-launch-vendor/vendored-source.json
+++ b/distros/rolling/gz-launch-vendor/vendored-source.json
@@ -1,5 +1,5 @@
 {
   "url": "https://github.com/gazebosim/gz-launch.git",
-  "rev": "gz-launch8_8.0.0",
-  "hash": "sha256-el+4sVBOmeBj8VJqKut8pIhVJeyEyodrt6titunbBBB="
+  "rev": "gz-launch8_8.0.1",
+  "hash": "sha256-el+4sVBOmeBj8VJqKut8pIhVJeyEyodrt6titunbBF0="
 }

--- a/distros/rolling/hardware-interface-testing/default.nix
+++ b/distros/rolling/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface-testing";
-  version = "4.26.0-r1";
+  version = "4.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface_testing/4.26.0-1.tar.gz";
-    name = "4.26.0-1.tar.gz";
-    sha256 = "4ad94ccca580c44200e8cd4ef50f6bbed1f76897543aba135c48d25666299d08";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface_testing/4.27.0-1.tar.gz";
+    name = "4.27.0-1.tar.gz";
+    sha256 = "150491273760cd5e7c1235c3568473f76ca52a67f6bdd91e6f3b4d7087f408cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/hardware-interface/default.nix
+++ b/distros/rolling/hardware-interface/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, control-msgs, joint-limits, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, realtime-tools, ros2-control-test-assets, sdformat-urdf, tinyxml2-vendor, urdf }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, control-msgs, joint-limits, lifecycle-msgs, pal-statistics, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, realtime-tools, ros2-control-test-assets, sdformat-urdf, tinyxml2-vendor, urdf }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface";
-  version = "4.26.0-r1";
+  version = "4.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/4.26.0-1.tar.gz";
-    name = "4.26.0-1.tar.gz";
-    sha256 = "de109b57a6f5d0a31a164dfe27ab62ebacc0357ece005839f393543d64b7d040";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/4.27.0-1.tar.gz";
+    name = "4.27.0-1.tar.gz";
+    sha256 = "9ae8c6bac1102bf9cec20237a4fb35d4096e696c3fd85eee30d9888e1ebe4195";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gen-version-h ];
   checkInputs = [ ament-cmake-gmock ros2-control-test-assets ];
-  propagatedBuildInputs = [ backward-ros control-msgs joint-limits lifecycle-msgs pluginlib rclcpp-lifecycle rcpputils rcutils realtime-tools sdformat-urdf tinyxml2-vendor urdf ];
+  propagatedBuildInputs = [ backward-ros control-msgs joint-limits lifecycle-msgs pal-statistics pluginlib rclcpp-lifecycle rcpputils rcutils realtime-tools sdformat-urdf tinyxml2-vendor urdf ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ];
 
   meta = {

--- a/distros/rolling/imu-sensor-broadcaster/default.nix
+++ b/distros/rolling/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-imu-sensor-broadcaster";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "0a6c8ea764bdaa730a89ebe6fd5e118f970b659af621342d460ad96024fa7de8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "7df358bea6ff2a79d1188685a78a5bebda0b4ab0961f29efe56ed8b5453d5c54";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-limits/default.nix
+++ b/distros/rolling/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-gtest, backward-ros, generate-parameter-library, launch-ros, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-limits";
-  version = "4.26.0-r1";
+  version = "4.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/4.26.0-1.tar.gz";
-    name = "4.26.0-1.tar.gz";
-    sha256 = "de6463208ce851cbc72509c357dfdb83afa3300d0f2370c50add08fe43aa2fbd";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/4.27.0-1.tar.gz";
+    name = "4.27.0-1.tar.gz";
+    sha256 = "3d96c61aa38962bae37fc9f01bbf2ac24ccad5fe46a5b156ff3d5e6515db7544";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-state-broadcaster/default.nix
+++ b/distros/rolling/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-state-broadcaster";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "53ec80d6646b7070d04422d29ed3504be97da9371c4a572c090f3a74d918526e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "ba4b3642d0a2156b8baee0826eb6ef76e0355b84c431d9a8ebd4c61d068c7697";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-trajectory-controller/default.nix
+++ b/distros/rolling/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-trajectory-controller";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "636b1f2fab899900e540ab7240bba69393c3159ca92bbf241e44930464d43fa6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "cc0e4311048a91742aaf116b00ef988e22d4b20c6e02a9f37a8f08ad767c1f6b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mecanum-drive-controller/default.nix
+++ b/distros/rolling/mecanum-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mecanum-drive-controller";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/mecanum_drive_controller/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "e004183eaaf84acebf1adfa9ec31c986c899a2e516daf5061d31f7a350253298";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/mecanum_drive_controller/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "67daf72f1d4712e5b8270a16dada069060ee84940738cafea8d03842a6b31229";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/parallel-gripper-controller/default.nix
+++ b/distros/rolling/parallel-gripper-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-parallel-gripper-controller";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/parallel_gripper_controller/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "73264e64006d3825d261b3058e0ffc02bdfae9c0d6f7043ca7a8b493842f7ecf";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/parallel_gripper_controller/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "081fc3c0911f9f320554196e15cf17dc8152a4038144b07d235f7993426c9b8d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pid-controller/default.nix
+++ b/distros/rolling/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-pid-controller";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pid_controller/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "3de4e87d83a758135d39cd6cd16b4323cbceb3ea399888c4b842fcfd06c4f72d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pid_controller/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "ed2cd91c44807b13454c9cc45547b5769a577bbc541ccdb01be7a7b797c50777";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pose-broadcaster/default.nix
+++ b/distros/rolling/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-pose-broadcaster";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pose_broadcaster/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "e6ddbabb4cf056f07dd014bd9bcb10d195a0beddc55d4c41499cf3338271dc58";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pose_broadcaster/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "310a14bf6d31a1d1674da5a4a44dc2dc24a064841ec24db1ef04909491d37a64";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/position-controllers/default.nix
+++ b/distros/rolling/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-position-controllers";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "e9172d28e9e6df71342ed3242aff5f73cdb9b1d2efbbc054315d78bc4b824bc4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "4e78bc5d24aef7a8295ef5cfc8992c227ada911c0188b8b0bcfa73550cbd5680";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/range-sensor-broadcaster/default.nix
+++ b/distros/rolling/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-range-sensor-broadcaster";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "bf9a701975b874ca291fb2bcf07cefe73918f9729ce95488cd3f691c770c92c3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "438709f4980eb271032afecad707b140ead7f75be177c68f9f45512ef661ecc8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-desert/default.nix
+++ b/distros/rolling/rmw-desert/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, rclcpp, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-cmake, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-cmake, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rmw-desert";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_desert-release/archive/release/rolling/rmw_desert/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "9a073296647bc12b81baac944fd3be4e4f75e5c58fa88a472e6388ea82374e1a";
+    url = "https://github.com/ros2-gbp/rmw_desert-release/archive/release/rolling/rmw_desert/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "7615250ac2a02bae7a0ce9c399cc1bf9a201fe366b5e462c277ef64f18a8801f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
-  propagatedBuildInputs = [ ament-cmake rclcpp rcpputils rcutils rmw rmw-dds-common rosidl-cmake rosidl-runtime-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp ];
+  propagatedBuildInputs = [ ament-cmake rcpputils rcutils rmw rmw-dds-common rosidl-cmake rosidl-runtime-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros rosidl-cmake ];
 
   meta = {

--- a/distros/rolling/rmw-fastrtps-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-cpp/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-dynamic-typesupport, rosidl-dynamic-typesupport-fastrtps, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs, tracetools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastdds, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-dynamic-typesupport, rosidl-dynamic-typesupport-fastrtps, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-cpp";
-  version = "9.2.0-r1";
+  version = "9.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_cpp/9.2.0-1.tar.gz";
-    name = "9.2.0-1.tar.gz";
-    sha256 = "c5710ff4833523d1589eadd0df85e9dd5f86aca48592a60f8c8ad87cd7632d40";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_cpp/9.3.0-1.tar.gz";
+    name = "9.3.0-1.tar.gz";
+    sha256 = "30c0d52caa2043721c6f13b18a359dd2c14cd06590efc89f0d928b99a33e7c8e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common osrf-testing-tools-cpp test-msgs ];
-  propagatedBuildInputs = [ ament-cmake fastcdr fastrtps fastrtps-cmake-module rcpputils rcutils rmw rmw-dds-common rmw-fastrtps-shared-cpp rosidl-dynamic-typesupport rosidl-dynamic-typesupport-fastrtps rosidl-runtime-c rosidl-runtime-cpp rosidl-typesupport-fastrtps-c rosidl-typesupport-fastrtps-cpp tracetools ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-ros fastrtps-cmake-module ];
+  propagatedBuildInputs = [ ament-cmake fastcdr fastdds rcpputils rcutils rmw rmw-dds-common rmw-fastrtps-shared-cpp rosidl-dynamic-typesupport rosidl-dynamic-typesupport-fastrtps rosidl-runtime-c rosidl-runtime-cpp rosidl-typesupport-fastrtps-c rosidl-typesupport-fastrtps-cpp tracetools ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 
   meta = {
     description = "Implement the ROS middleware interface using eProsima FastRTPS static code generation in C++.";

--- a/distros/rolling/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-dynamic-cpp/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs, tracetools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastdds, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-dynamic-cpp";
-  version = "9.2.0-r1";
+  version = "9.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_dynamic_cpp/9.2.0-1.tar.gz";
-    name = "9.2.0-1.tar.gz";
-    sha256 = "c8cc95f32c9c460253eb4694dd7b04378ccf9d4af54d1d69c3167645f5b4b888";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_dynamic_cpp/9.3.0-1.tar.gz";
+    name = "9.3.0-1.tar.gz";
+    sha256 = "01fc3b864f3b68b2eb38146287e328713def70ba9be816e24ed7689ee9ad940b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common osrf-testing-tools-cpp test-msgs ];
-  propagatedBuildInputs = [ ament-cmake fastcdr fastrtps fastrtps-cmake-module rcpputils rcutils rmw rmw-dds-common rmw-fastrtps-shared-cpp rosidl-runtime-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp tracetools ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-ros fastrtps-cmake-module ];
+  propagatedBuildInputs = [ ament-cmake fastcdr fastdds rcpputils rcutils rmw rmw-dds-common rmw-fastrtps-shared-cpp rosidl-runtime-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp tracetools ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 
   meta = {
     description = "Implement the ROS middleware interface using introspection type support.";

--- a/distros/rolling/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-shared-cpp/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastdds, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-security-common, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-shared-cpp";
-  version = "9.2.0-r1";
+  version = "9.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_shared_cpp/9.2.0-1.tar.gz";
-    name = "9.2.0-1.tar.gz";
-    sha256 = "3decde6188505319b9ae51025390e9739c6238a45a17d0c7b11d485f00a133e6";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_shared_cpp/9.3.0-1.tar.gz";
+    name = "9.3.0-1.tar.gz";
+    sha256 = "ae852cf58bc20756740aa37d74e843fa34dedb41c9e8188b319860a2a8dec570";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros rosidl-runtime-c ];
   checkInputs = [ ament-lint-auto ament-lint-common osrf-testing-tools-cpp ];
-  propagatedBuildInputs = [ ament-cmake fastcdr fastrtps fastrtps-cmake-module rcpputils rcutils rmw rmw-dds-common rosidl-dynamic-typesupport rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp tracetools ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-ros fastrtps-cmake-module ];
+  propagatedBuildInputs = [ ament-cmake fastcdr fastdds rcpputils rcutils rmw rmw-dds-common rmw-security-common rosidl-dynamic-typesupport rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp tracetools ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 
   meta = {
     description = "Code shared on static and dynamic type support of rmw_fastrtps_cpp.";

--- a/distros/rolling/rmw-implementation-cmake/default.nix
+++ b/distros/rolling/rmw-implementation-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rmw-implementation-cmake";
-  version = "7.7.0-r1";
+  version = "7.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw_implementation_cmake/7.7.0-1.tar.gz";
-    name = "7.7.0-1.tar.gz";
-    sha256 = "243c8a4ef50acb160192772982d0c69a60579eaf53fb5332dd08bf5d9d71e2fe";
+    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw_implementation_cmake/7.8.0-1.tar.gz";
+    name = "7.8.0-1.tar.gz";
+    sha256 = "68fa286fea0475431d6bbaa55590da4b3d114df420248f7074a29ae72b18c676";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-security-common/default.nix
+++ b/distros/rolling/rmw-security-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-rolling-rmw-security-common";
-  version = "7.7.0-r1";
+  version = "7.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw_security_common/7.7.0-1.tar.gz";
-    name = "7.7.0-1.tar.gz";
-    sha256 = "cdb11636ce9d0386e3246fc62f527b0ef510dc83840f6d86525e3a08593ae724";
+    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw_security_common/7.8.0-1.tar.gz";
+    name = "7.8.0-1.tar.gz";
+    sha256 = "d081711341a8c8ceb5d33290a02e01d7d94a8c449d4dfffc02bdd548b5c1d5be";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw/default.nix
+++ b/distros/rolling/rmw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-cmake-version, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcutils, rosidl-dynamic-typesupport, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-rolling-rmw";
-  version = "7.7.0-r1";
+  version = "7.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw/7.7.0-1.tar.gz";
-    name = "7.7.0-1.tar.gz";
-    sha256 = "d1dbf81a01185e12a6377f80015fdd87649c88f6ac4d0afa1d2227084eae2938";
+    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw/7.8.0-1.tar.gz";
+    name = "7.8.0-1.tar.gz";
+    sha256 = "b566c0119f44b784e43935cdc69cb2fccbfe2ad1e52a843137c02ef2238324ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control-test-assets/default.nix
+++ b/distros/rolling/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control-test-assets";
-  version = "4.26.0-r1";
+  version = "4.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/4.26.0-1.tar.gz";
-    name = "4.26.0-1.tar.gz";
-    sha256 = "e4b6b58dafaa7b05de3461aeac08f5172e7c0469a3586771d787f526154627a5";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/4.27.0-1.tar.gz";
+    name = "4.27.0-1.tar.gz";
+    sha256 = "0e315bf6296bbff895eb6af67386c2a7d30c85cd52d2a634ec1bad9ea7a35f0d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control/default.nix
+++ b/distros/rolling/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control";
-  version = "4.26.0-r1";
+  version = "4.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/4.26.0-1.tar.gz";
-    name = "4.26.0-1.tar.gz";
-    sha256 = "1c51f30ea9137641b2ebe6521fa77c6cf90ce4bf305521ed0f35a4d09a25b28b";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/4.27.0-1.tar.gz";
+    name = "4.27.0-1.tar.gz";
+    sha256 = "1fc4db7143aece0e8cc9a93602e1f6fefcf9e136f54fe98a82adac03959f0aef";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-controllers-test-nodes/default.nix
+++ b/distros/rolling/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers-test-nodes";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "f4bae215ee1b9628e55cac73de529b7583a3fec4db08aa494b6dda14072e4f65";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "f949aa3dd4651fd2dfe70c4051ce67a7f8275b5b49e2d153df26a5a8ac6485f5";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2-controllers/default.nix
+++ b/distros/rolling/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gripper-controllers, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, parallel-gripper-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "5b2a70a3a85fcfde79eb0d52b92545000756acaec1e0f039fe51993635260be9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "37d8a6cef747693392af481f30339d7a3706328104dafbe520761bb672db5abb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2controlcli/default.nix
+++ b/distros/rolling/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-rolling-ros2controlcli";
-  version = "4.26.0-r1";
+  version = "4.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/4.26.0-1.tar.gz";
-    name = "4.26.0-1.tar.gz";
-    sha256 = "f36ba9674340f25443dd67b462ba5ac1ecff9359efd36553bdca556bb5729cee";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/4.27.0-1.tar.gz";
+    name = "4.27.0-1.tar.gz";
+    sha256 = "d70553cd832faef1469aa02a093a64a7305a77a2d6b8ba7db49e0366575767fe";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosidl-dynamic-typesupport-fastrtps/default.nix
+++ b/distros/rolling/rosidl-dynamic-typesupport-fastrtps/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, fastcdr, fastrtps, fastrtps-cmake-module, rcutils, rosidl-dynamic-typesupport }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, fastcdr, fastdds, rcpputils, rcutils, rosidl-dynamic-typesupport }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-dynamic-typesupport-fastrtps";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_dynamic_typesupport_fastrtps-release/archive/release/rolling/rosidl_dynamic_typesupport_fastrtps/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "4db40019b639d0e0ef056ae57586ba7398fec3a99ef97535d61feab546da5beb";
+    url = "https://github.com/ros2-gbp/rosidl_dynamic_typesupport_fastrtps-release/archive/release/rolling/rosidl_dynamic_typesupport_fastrtps/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "c19e19f221de4d11d34df239da453f47b5ad6c081cc78a5e0ea534a4fb182732";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros fastrtps-cmake-module ];
-  propagatedBuildInputs = [ fastcdr fastrtps rcutils rosidl-dynamic-typesupport ];
-  nativeBuildInputs = [ ament-cmake-ros fastrtps-cmake-module ];
+  buildInputs = [ ament-cmake-ros ];
+  propagatedBuildInputs = [ fastcdr fastdds rcpputils rcutils rosidl-dynamic-typesupport ];
+  nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {
     description = "FastDDS serialization support implementation for use with C/C++.";

--- a/distros/rolling/rqt-controller-manager/default.nix
+++ b/distros/rolling/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-controller-manager";
-  version = "4.26.0-r1";
+  version = "4.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/4.26.0-1.tar.gz";
-    name = "4.26.0-1.tar.gz";
-    sha256 = "013ae7bffab1f5da595b376644e0c6030d55f1d3cbf3c723e07b7a1c15702107";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/4.27.0-1.tar.gz";
+    name = "4.27.0-1.tar.gz";
+    sha256 = "5475cc578dcef096af854aca217fec961821897b05635d18b522847016c62c28";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-joint-trajectory-controller/default.nix
+++ b/distros/rolling/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-joint-trajectory-controller";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "51ead15e7eed763b298059577ba49311440b3c5e98ed6d55181644e593fd6d3d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "8c65c7771a0b19ee296face87b2b1076c6fb9d72493266b4c2925f14d351800c";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rviz-assimp-vendor/default.nix
+++ b/distros/rolling/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-rolling-rviz-assimp-vendor";
-  version = "14.4.3-r1";
+  version = "14.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/14.4.3-1.tar.gz";
-    name = "14.4.3-1.tar.gz";
-    sha256 = "cc9dcd132046e1e6cbd0d257b1e5f56cc66bc2a18526322747f9ea36e331067c";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/14.4.2-1.tar.gz";
+    name = "14.4.2-1.tar.gz";
+    sha256 = "a56acf0cac95056941834edd5dbfda1facc9b82c20d8419d56d1a23ed692f146";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-common/default.nix
+++ b/distros/rolling/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-common";
-  version = "14.4.3-r1";
+  version = "14.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/14.4.3-1.tar.gz";
-    name = "14.4.3-1.tar.gz";
-    sha256 = "ea4e5440ad8375e7153708da72521e1dd8f6eebeb78a6c62b7c6ac00a4e35541";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/14.4.2-1.tar.gz";
+    name = "14.4.2-1.tar.gz";
+    sha256 = "b881d1c2664e76d9faa4e9211335bf6abe5b5e105332af6c0da8bdd5041e38b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-default-plugins/default.nix
+++ b/distros/rolling/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, gz-math-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz-default-plugins";
-  version = "14.4.3-r1";
+  version = "14.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/14.4.3-1.tar.gz";
-    name = "14.4.3-1.tar.gz";
-    sha256 = "ceb45ebba63c81a045fa59935b25ebbe77c7dbb56c7b5b54c7432fc566a3ad19";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/14.4.2-1.tar.gz";
+    name = "14.4.2-1.tar.gz";
+    sha256 = "d67789c951ca9b8661e200a8934523c043dbded66ef5909b6f3c396adfe486b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-ogre-vendor/default.nix
+++ b/distros/rolling/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-rolling-rviz-ogre-vendor";
-  version = "14.4.3-r1";
+  version = "14.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/14.4.3-1.tar.gz";
-    name = "14.4.3-1.tar.gz";
-    sha256 = "2045c56d1182cb3b81b294f45bc01ae2276f22506e71e8bfd67ce9ec4c50d5d2";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/14.4.2-1.tar.gz";
+    name = "14.4.2-1.tar.gz";
+    sha256 = "274b5005343f9235f0092f7943c4dab0e3ffb23e7c52e621152311bb241d9667";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering-tests/default.nix
+++ b/distros/rolling/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering-tests";
-  version = "14.4.3-r1";
+  version = "14.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/14.4.3-1.tar.gz";
-    name = "14.4.3-1.tar.gz";
-    sha256 = "be19bc8f0cf7eacc01097e9a759a76ba56fd6c51e15531cf9363eb5ced67bfdc";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/14.4.2-1.tar.gz";
+    name = "14.4.2-1.tar.gz";
+    sha256 = "b498377136ed6c40982c9a7f652d9c17b98c2eaf4daeec03c3df2d9eca42d478";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering/default.nix
+++ b/distros/rolling/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering";
-  version = "14.4.3-r1";
+  version = "14.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/14.4.3-1.tar.gz";
-    name = "14.4.3-1.tar.gz";
-    sha256 = "33e652d79e6fc61a8b3a52a29b91caa02735044698ec02a68133b226e69f3a32";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/14.4.2-1.tar.gz";
+    name = "14.4.2-1.tar.gz";
+    sha256 = "ddea9db88b67a2b3dcbb5bf4617e1c153f3f742b47ded9995d936b8f2856d783";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-visual-testing-framework/default.nix
+++ b/distros/rolling/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rviz-visual-testing-framework";
-  version = "14.4.3-r1";
+  version = "14.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/14.4.3-1.tar.gz";
-    name = "14.4.3-1.tar.gz";
-    sha256 = "a59d70905db8431e1b3a4d755da009c10d4dc2ba0c416f2a3491c7561abf2c11";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/14.4.2-1.tar.gz";
+    name = "14.4.2-1.tar.gz";
+    sha256 = "8b4e2bda4d47cc0f00420ee33e4886e77f052e6f2bb76bc9c204bf0458669236";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz2/default.nix
+++ b/distros/rolling/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz2";
-  version = "14.4.3-r1";
+  version = "14.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/14.4.3-1.tar.gz";
-    name = "14.4.3-1.tar.gz";
-    sha256 = "4ffdff06eedc1f74cc53a21309a4abbe9c3133bd7de76809b519e9fc8902a6e8";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/14.4.2-1.tar.gz";
+    name = "14.4.2-1.tar.gz";
+    sha256 = "feb1a5bf610ac10a44678e62272f83a84f5e0360699bec08d8c1362bd15b6c8c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/steering-controllers-library/default.nix
+++ b/distros/rolling/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-steering-controllers-library";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "aac000d7d6dfd97ed0c766ffae0884fb3a2ed8c9a93d1cd1d65cca9a64dc9f5b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "af6af746d15562b743c303bc4347dba2c5e68dc4e5f0aefda1a75af7ba745d1e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/transmission-interface/default.nix
+++ b/distros/rolling/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, hardware-interface, pluginlib, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-transmission-interface";
-  version = "4.26.0-r1";
+  version = "4.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/4.26.0-1.tar.gz";
-    name = "4.26.0-1.tar.gz";
-    sha256 = "3cf9b36b5c570256c9c3cd0eb7a60d2c4363fed0a244932a38845c712add8eeb";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/4.27.0-1.tar.gz";
+    name = "4.27.0-1.tar.gz";
+    sha256 = "7a19b2d390dab6a450fd4e9a70a33652def7f60c817f646ba2b14306e60348e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-controller/default.nix
+++ b/distros/rolling/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-controller";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "af3ca146f45d56323513ce420e4985f8eac3deb956fffc71e6c6b6fd3b175794";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "a3312eb75826690f43d749c0001c2d27b09bf6c42024cd7d82afc58a9f746db5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-steering-controller/default.nix
+++ b/distros/rolling/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-steering-controller";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "763ec2c198fc78e3fe7c9d4c6c9cf9caa6df67976ef57cd5174826809e95a49e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "3acf45804cfdffc55fdcd044a6d5cf0affa813e9b41b2f273f82bff1ede2b9b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-calibration/default.nix
+++ b/distros/rolling/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-ur-calibration";
-  version = "3.0.2-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_calibration/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "a9644608f16baaa1991ad1c60ef805fba791a2f7b2cf7544e4075d9eef6202b6";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_calibration/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "7abf40f9131c61591f74b5a8ffb2e51416da26c63517053eb4fc0258a6214bd1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-controllers/default.nix
+++ b/distros/rolling/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, angles, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, trajectory-msgs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ur-controllers";
-  version = "3.0.2-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_controllers/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "6127a6e91ad053eb9e81504f739c54de9faf383f6e1d4577d864b33b7ff4a01c";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_controllers/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "fc2aa1ab272f7e2d8edf25cc78de7abe77a21fd4e218be43a0fb288953ab5824";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-dashboard-msgs/default.nix
+++ b/distros/rolling/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-ur-dashboard-msgs";
-  version = "3.0.2-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_dashboard_msgs/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "ec39b7b6f84dfe55025bafb079c772f4864b5db57c86a6d96a036e47acf7b643";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_dashboard_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "dc9b6cc85d0be68d4c3f965f5a878a1604b8c2ef11bb60a01d9d384417e9116a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-moveit-config/default.nix
+++ b/distros/rolling/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, ur-description, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-rolling-ur-moveit-config";
-  version = "3.0.2-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_moveit_config/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "6a9a4574aa02e7a19030b8edced45b93d6533d2c206b08f7c4993f09419cc216";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_moveit_config/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "28a5f3c6d95c929a35b5c2fc13a91aebf48a0acef0b0a1a06f400401d82edd3e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-robot-driver/default.nix
+++ b/distros/rolling/ur-robot-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, backward-ros, controller-manager, controller-manager-msgs, force-torque-sensor-broadcaster, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, pluginlib, pose-broadcaster, position-controllers, rclcpp, rclcpp-lifecycle, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, socat, std-msgs, std-srvs, tf2-geometry-msgs, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-rolling-ur-robot-driver";
-  version = "3.0.2-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_robot_driver/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "c2902bc6edd33201caa299385c6a7e182dd2e7034100eba69c06e75e9e54513a";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_robot_driver/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "990841d04e8d54a143a1687bf150627fea8c99054258d0397b52ed7a49f79c14";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur/default.nix
+++ b/distros/rolling/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-rolling-ur";
-  version = "3.0.2-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "eec0299fb678b1b8ac2765bfada4600b9630557c0e3c39dda4047297860f2c18";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "df33f1e04f6536d5127ff8d84a5fd50c9cb48c2e603ece6383c7bd396c5c8a1e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/velocity-controllers/default.nix
+++ b/distros/rolling/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-velocity-controllers";
-  version = "4.20.0-r1";
+  version = "4.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/4.20.0-1.tar.gz";
-    name = "4.20.0-1.tar.gz";
-    sha256 = "8a2b9dbab57252a973aa46e23a1d0b0e000bec8d871c71090a15593e267ea20a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/4.21.0-1.tar.gz";
+    name = "4.21.0-1.tar.gz";
+    sha256 = "0916850682f1a9366e11af4cf8282b4aa55c1b1c26bd840c70749873d6f85475";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'noetic', 'rolling'] from nix-ros-overlay commit 7e97da57debd674365f8276b9680b285f637beee.
This pull request was generated by running the following command:

```
superflore-gen-nix --dry-run --tar-archive-dir /home/runner/.ros/tar --output-repository-path . --upstream-branch ament-vendor-auto-update-test --all
```

Changes:
========
Humble Changes:
---------------
* *apriltag-detector 2.1.0-r1 --> 3.0.1-r1*
* *apriltag-detector-mit 2.1.0-r1 --> 3.0.1-r1*
* *apriltag-detector-umich 2.1.0-r1 --> 3.0.1-r1*
* *apriltag-draw 2.1.0-r1 --> 3.0.1-r1*
* *apriltag-tools 3.0.1-r1*
* *camera-calibration 3.0.6-r1 --> 3.0.7-r1*
* *clearpath-config 1.1.0-r1 --> 1.1.1-r1*
* *depth-image-proc 3.0.6-r1 --> 3.0.7-r1*
* *image-pipeline 3.0.6-r1 --> 3.0.7-r1*
* *image-proc 3.0.6-r1 --> 3.0.7-r1*
* *image-publisher 3.0.6-r1 --> 3.0.7-r1*
* *image-rotate 3.0.6-r1 --> 3.0.7-r1*
* *image-view 3.0.6-r1 --> 3.0.7-r1*
* *kinova-gen3-6dof-robotiq-2f-85-moveit-config 0.2.2-r1 --> 0.2.3-r1*
* *kinova-gen3-7dof-robotiq-2f-85-moveit-config 0.2.2-r1 --> 0.2.3-r1*
* *kinova-gen3-lite-moveit-config 0.2.3-r1*
* *kortex-api 0.2.2-r1 --> 0.2.3-r1*
* *kortex-bringup 0.2.2-r1 --> 0.2.3-r1*
* *kortex-description 0.2.2-r1 --> 0.2.3-r1*
* *kortex-driver 0.2.2-r1 --> 0.2.3-r1*
* *launch-pal 0.10.0-r1 --> 0.11.0-r1*
* *omni-base-2dnav 2.4.0-r1 --> 2.12.1-r1*
* *omni-base-bringup 2.4.1-r1 --> 2.9.0-r1*
* *omni-base-controller-configuration 2.4.1-r1 --> 2.9.0-r1*
* *omni-base-description 2.4.1-r1 --> 2.9.0-r1*
* *omni-base-gazebo 2.2.0-r1 --> 2.4.0-r1*
* *omni-base-laser-sensors 2.4.0-r1 --> 2.12.1-r1*
* *omni-base-navigation 2.4.0-r1 --> 2.12.1-r1*
* *omni-base-rgbd-sensors 2.4.0-r1 --> 2.12.1-r1*
* *omni-base-robot 2.4.1-r1 --> 2.9.0-r1*
* *omni-base-simulation 2.2.0-r1 --> 2.4.0-r1*
* *pal-gripper 3.4.0-r1 --> 3.5.0-r1*
* *pal-gripper-controller-configuration 3.4.0-r1 --> 3.5.0-r1*
* *pal-gripper-description 3.4.0-r1 --> 3.5.0-r1*
* *pal-gripper-simulation 3.4.0-r1 --> 3.5.0-r1*
* *play-motion2 1.3.0-r1 --> 1.5.0-r1*
* *play-motion2-msgs 1.3.0-r1 --> 1.5.0-r1*
* *pmb2-2dnav 4.5.0-r1 --> 4.11.0-r1*
* *pmb2-bringup 5.4.0-r1 --> 5.7.0-r1*
* *pmb2-controller-configuration 5.4.0-r1 --> 5.7.0-r1*
* *pmb2-description 5.4.0-r1 --> 5.7.0-r1*
* *pmb2-gazebo 4.1.0-r1 --> 4.3.0-r1*
* *pmb2-laser-sensors 4.5.0-r1 --> 4.11.0-r1*
* *pmb2-navigation 4.5.0-r1 --> 4.11.0-r1*
* *pmb2-rgbd-sensors 4.11.0-r1*
* *pmb2-robot 5.4.0-r1 --> 5.7.0-r1*
* *pmb2-simulation 4.1.0-r1 --> 4.3.0-r1*
* *realtime-tools 2.11.0-r1 --> 2.12.0-r1*
* *rmw-desert 1.0.3-r1*
* *stereo-image-proc 3.0.6-r1 --> 3.0.7-r1*
* *talos-moveit-config 2.0.0-r1 --> 2.0.1-r1*
* *tiago-2dnav 4.5.0-r1 --> 4.9.0-r1*
* *tiago-bringup 4.7.1-r1 --> 4.14.0-r1*
* *tiago-controller-configuration 4.7.1-r1 --> 4.14.0-r1*
* *tiago-description 4.7.1-r1 --> 4.14.0-r1*
* *tiago-laser-sensors 4.5.0-r1 --> 4.9.0-r1*
* *tiago-moveit-config 3.1.1-r1 --> 3.1.2-r1*
* *tiago-navigation 4.5.0-r1 --> 4.9.0-r1*
* *tiago-rgbd-sensors 4.9.0-r1*
* *tiago-robot 4.7.1-r1 --> 4.14.0-r1*
* *tracetools-image-pipeline 3.0.6-r1 --> 3.0.7-r1*
* *turtlebot4-ignition-bringup 1.0.2-r1 --> 1.0.3-r1*
* *turtlebot4-ignition-toolbox 1.0.2-r1 --> 1.0.3-r1*
* *turtlebot4-setup 1.0.5-r1 --> 1.0.6-r1*
* *turtlebot4-simulator 1.0.2-r1 --> 1.0.3-r1*
* *wireless-msgs 1.1.2-r1 --> 1.1.3-r1*
* *wireless-watcher 1.1.2-r1 --> 1.1.3-r1*

Jazzy Changes:
--------------
* *ackermann-steering-controller 4.20.0-r1 --> 4.21.0-r1*
* *admittance-controller 4.20.0-r1 --> 4.21.0-r1*
* *apriltag-detector 1.0.0-r3 --> 3.0.1-r1*
* *apriltag-detector-mit 3.0.1-r1*
* *apriltag-detector-umich 3.0.1-r1*
* *apriltag-draw 3.0.1-r1*
* *apriltag-tools 3.0.1-r1*
* *bicycle-steering-controller 4.20.0-r1 --> 4.21.0-r1*
* *camera-calibration 5.0.8-r1 --> 5.0.9-r1*
* *controller-interface 4.26.0-r1 --> 4.27.0-r1*
* *controller-manager 4.26.0-r1 --> 4.27.0-r1*
* *controller-manager-msgs 4.26.0-r1 --> 4.27.0-r1*
* *depth-image-proc 5.0.8-r1 --> 5.0.9-r1*
* *diff-drive-controller 4.20.0-r1 --> 4.21.0-r1*
* *effort-controllers 4.20.0-r1 --> 4.21.0-r1*
* *force-torque-sensor-broadcaster 4.20.0-r1 --> 4.21.0-r1*
* *forward-command-controller 4.20.0-r1 --> 4.21.0-r1*
* *gpio-controllers 4.20.0-r1 --> 4.21.0-r1*
* *gripper-controllers 4.20.0-r1 --> 4.21.0-r1*
* *hardware-interface 4.26.0-r1 --> 4.27.0-r1*
* *hardware-interface-testing 4.26.0-r1 --> 4.27.0-r1*
* *image-pipeline 5.0.8-r1 --> 5.0.9-r1*
* *image-proc 5.0.8-r1 --> 5.0.9-r1*
* *image-publisher 5.0.8-r1 --> 5.0.9-r1*
* *image-rotate 5.0.8-r1 --> 5.0.9-r1*
* *image-view 5.0.8-r1 --> 5.0.9-r1*
* *imu-sensor-broadcaster 4.20.0-r1 --> 4.21.0-r1*
* *joint-limits 4.26.0-r1 --> 4.27.0-r1*
* *joint-state-broadcaster 4.20.0-r1 --> 4.21.0-r1*
* *joint-trajectory-controller 4.20.0-r1 --> 4.21.0-r1*
* *mecanum-drive-controller 4.20.0-r1 --> 4.21.0-r1*
* *parallel-gripper-controller 4.20.0-r1 --> 4.21.0-r1*
* *pid-controller 4.20.0-r1 --> 4.21.0-r1*
* *pose-broadcaster 4.20.0-r1 --> 4.21.0-r1*
* *position-controllers 4.20.0-r1 --> 4.21.0-r1*
* *range-sensor-broadcaster 4.20.0-r1 --> 4.21.0-r1*
* *rmw-desert 1.0.3-r1*
* *ros2-control 4.26.0-r1 --> 4.27.0-r1*
* *ros2-control-test-assets 4.26.0-r1 --> 4.27.0-r1*
* *ros2-controllers 4.20.0-r1 --> 4.21.0-r1*
* *ros2-controllers-test-nodes 4.20.0-r1 --> 4.21.0-r1*
* *ros2controlcli 4.26.0-r1 --> 4.27.0-r1*
* *rqt-controller-manager 4.26.0-r1 --> 4.27.0-r1*
* *rqt-joint-trajectory-controller 4.20.0-r1 --> 4.21.0-r1*
* *rviz-satellite 4.1.0-r1 --> 4.1.0-r2*
* *steering-controllers-library 4.20.0-r1 --> 4.21.0-r1*
* *stereo-image-proc 5.0.8-r1 --> 5.0.9-r1*
* *tracetools-image-pipeline 5.0.8-r1 --> 5.0.9-r1*
* *transmission-interface 4.26.0-r1 --> 4.27.0-r1*
* *tricycle-controller 4.20.0-r1 --> 4.21.0-r1*
* *tricycle-steering-controller 4.20.0-r1 --> 4.21.0-r1*
* *turtlebot4-setup 2.0.2-r1 --> 2.0.3-r1*
* *ur 3.0.2-r1 --> 3.1.0-r1*
* *ur-calibration 3.0.2-r1 --> 3.1.0-r1*
* *ur-controllers 3.0.2-r1 --> 3.1.0-r1*
* *ur-dashboard-msgs 3.0.2-r1 --> 3.1.0-r1*
* *ur-moveit-config 3.0.2-r1 --> 3.1.0-r1*
* *ur-robot-driver 3.0.2-r1 --> 3.1.0-r1*
* *velocity-controllers 4.20.0-r1 --> 4.21.0-r1*
* *velodyne-description 2.0.3-r4 --> 2.0.4-r1*
* *wireless-msgs 1.1.2-r1 --> 1.1.3-r1*
* *wireless-watcher 1.1.2-r1 --> 1.1.3-r1*

Rolling Changes:
----------------
* *ackermann-steering-controller 4.20.0-r1 --> 4.21.0-r1*
* *admittance-controller 4.20.0-r1 --> 4.21.0-r1*
* *apriltag-detector 2.0.0-r1 --> 3.0.1-r2*
* *apriltag-detector-mit 2.0.0-r1 --> 3.0.1-r2*
* *apriltag-detector-umich 2.0.0-r1 --> 3.0.1-r2*
* *apriltag-draw 2.0.0-r1 --> 3.0.1-r2*
* *apriltag-tools 3.0.1-r2*
* *bicycle-steering-controller 4.20.0-r1 --> 4.21.0-r1*
* *controller-interface 4.26.0-r1 --> 4.27.0-r1*
* *controller-manager 4.26.0-r1 --> 4.27.0-r1*
* *controller-manager-msgs 4.26.0-r1 --> 4.27.0-r1*
* *diff-drive-controller 4.20.0-r1 --> 4.21.0-r1*
* *effort-controllers 4.20.0-r1 --> 4.21.0-r1*
* *fastdds 3.1.2-r1 --> 3.1.2-r2*
* *force-torque-sensor-broadcaster 4.20.0-r1 --> 4.21.0-r1*
* *forward-command-controller 4.20.0-r1 --> 4.21.0-r1*
* *gpio-controllers 4.20.0-r1 --> 4.21.0-r1*
* *gripper-controllers 4.20.0-r1 --> 4.21.0-r1*
* *hardware-interface 4.26.0-r1 --> 4.27.0-r1*
* *hardware-interface-testing 4.26.0-r1 --> 4.27.0-r1*
* *imu-sensor-broadcaster 4.20.0-r1 --> 4.21.0-r1*
* *joint-limits 4.26.0-r1 --> 4.27.0-r1*
* *joint-state-broadcaster 4.20.0-r1 --> 4.21.0-r1*
* *joint-trajectory-controller 4.20.0-r1 --> 4.21.0-r1*
* *mecanum-drive-controller 4.20.0-r1 --> 4.21.0-r1*
* *parallel-gripper-controller 4.20.0-r1 --> 4.21.0-r1*
* *pid-controller 4.20.0-r1 --> 4.21.0-r1*
* *pose-broadcaster 4.20.0-r1 --> 4.21.0-r1*
* *position-controllers 4.20.0-r1 --> 4.21.0-r1*
* *range-sensor-broadcaster 4.20.0-r1 --> 4.21.0-r1*
* *rmw 7.7.0-r1 --> 7.8.0-r1*
* *rmw-desert 1.0.1-r1 --> 1.0.3-r1*
* *rmw-fastrtps-cpp 9.2.0-r1 --> 9.3.0-r1*
* *rmw-fastrtps-dynamic-cpp 9.2.0-r1 --> 9.3.0-r1*
* *rmw-fastrtps-shared-cpp 9.2.0-r1 --> 9.3.0-r1*
* *rmw-implementation-cmake 7.7.0-r1 --> 7.8.0-r1*
* *rmw-security-common 7.7.0-r1 --> 7.8.0-r1*
* *ros2-control 4.26.0-r1 --> 4.27.0-r1*
* *ros2-control-test-assets 4.26.0-r1 --> 4.27.0-r1*
* *ros2-controllers 4.20.0-r1 --> 4.21.0-r1*
* *ros2-controllers-test-nodes 4.20.0-r1 --> 4.21.0-r1*
* *ros2controlcli 4.26.0-r1 --> 4.27.0-r1*
* *rosidl-dynamic-typesupport-fastrtps 0.3.0-r1 --> 0.4.0-r1*
* *rqt-controller-manager 4.26.0-r1 --> 4.27.0-r1*
* *rqt-joint-trajectory-controller 4.20.0-r1 --> 4.21.0-r1*
* *rviz-assimp-vendor 14.4.3-r1 --> 14.4.2-r1*
* *rviz-common 14.4.3-r1 --> 14.4.2-r1*
* *rviz-default-plugins 14.4.3-r1 --> 14.4.2-r1*
* *rviz-ogre-vendor 14.4.3-r1 --> 14.4.2-r1*
* *rviz-rendering 14.4.3-r1 --> 14.4.2-r1*
* *rviz-rendering-tests 14.4.3-r1 --> 14.4.2-r1*
* *rviz-visual-testing-framework 14.4.3-r1 --> 14.4.2-r1*
* *rviz2 14.4.3-r1 --> 14.4.2-r1*
* *steering-controllers-library 4.20.0-r1 --> 4.21.0-r1*
* *transmission-interface 4.26.0-r1 --> 4.27.0-r1*
* *tricycle-controller 4.20.0-r1 --> 4.21.0-r1*
* *tricycle-steering-controller 4.20.0-r1 --> 4.21.0-r1*
* *ur 3.0.2-r1 --> 3.1.0-r1*
* *ur-calibration 3.0.2-r1 --> 3.1.0-r1*
* *ur-controllers 3.0.2-r1 --> 3.1.0-r1*
* *ur-dashboard-msgs 3.0.2-r1 --> 3.1.0-r1*
* *ur-moveit-config 3.0.2-r1 --> 3.1.0-r1*
* *ur-robot-driver 3.0.2-r1 --> 3.1.0-r1*
* *velocity-controllers 4.20.0-r1 --> 4.21.0-r1*


Missing Dependencies:
=====================
 * [ ] action_tutorials_interfaces
 * [ ] atlas
 * [ ] autoware_utils
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] fastrtps_cmake_module
 * [ ] festival
 * [ ] gazebo_ros2_control
 * [ ] gazebo_ros_pkgs
 * [ ] gurumdds-3.0
 * [ ] gurumdds-3.2
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-httpx
 * [ ] python3-icecream
 * [ ] python3-marisa
 * [ ] python3-platformdirs
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-pysnmp-mibs
 * [ ] python3-pytorch-pip
 * [ ] python3-rosdep
 * [ ] python3-setproctitle
 * [ ] python3-torch-geometric-pip
 * [ ] python3-wheel
 * [ ] qtbase5-private-dev
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote