### PR TITLE
rosdistro sync, Mon Sep  8 21:51:48 2025

### DIFF
--- a/distros/humble/async-web-server-cpp/default.nix
+++ b/distros/humble/async-web-server-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, boost, launch-testing, openssl, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-async-web-server-cpp";
-  version = "2.0.0-r3";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/async_web_server_cpp-release/archive/release/humble/async_web_server_cpp/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "c9f5968c670996bfd9d697b4630791573042044433f5fd9aaef7d8cf280cd60d";
+    url = "https://github.com/ros2-gbp/async_web_server_cpp-release/archive/release/humble/async_web_server_cpp/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "74a3cf55f766d913415f400994001e54450271c795eb375ea53187c28b9563e4";
   };
 
   buildType = "catkin";

--- a/distros/humble/at-sonde-ros-driver/default.nix
+++ b/distros/humble/at-sonde-ros-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, libmodbus, rclcpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-at-sonde-ros-driver";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/at_sonde_ros_driver-release/archive/release/humble/at_sonde_ros_driver/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "07947c497c105a66471ee8bb2bcaf8a139e4a0333a161ff14b998ff2a92209d0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ libmodbus rclcpp std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A ROS 2 driver to stream the monitored parameters of an In-Situ Aqua TROLL Multiparameter Sonde.";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/automatika-embodied-agents/default.nix
+++ b/distros/humble/automatika-embodied-agents/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, automatika-ros-sugar, builtin-interfaces, python3Packages, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-automatika-embodied-agents";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/automatika_embodied_agents-release/archive/release/humble/automatika_embodied_agents/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "0e12eebfe826cb9bb1705bc33a83c7fb4d9a0ac33031819da7079a05159b18c6";
+    url = "https://github.com/ros2-gbp/automatika_embodied_agents-release/archive/release/humble/automatika_embodied_agents/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "bc1efa5ba1903a4c2225d31c6a7f8a8778f80882883bf4693243f50d6f51c561";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -290,6 +290,8 @@ self: super: {
 
  async-web-server-cpp = self.callPackage ./async-web-server-cpp {};
 
+ at-sonde-ros-driver = self.callPackage ./at-sonde-ros-driver {};
+
  automatika-embodied-agents = self.callPackage ./automatika-embodied-agents {};
 
  automatika-ros-sugar = self.callPackage ./automatika-ros-sugar {};

--- a/distros/humble/launch-pal/default.nix
+++ b/distros/humble/launch-pal/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-launch-pal";
-  version = "0.14.1-r1";
+  version = "0.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/launch_pal-release/archive/release/humble/launch_pal/0.14.1-1.tar.gz";
-    name = "0.14.1-1.tar.gz";
-    sha256 = "5568a6ce7a9e1d8b1d09a315dfa83c087769b4be82e0b250384d5c6ecbe5a434";
+    url = "https://github.com/pal-gbp/launch_pal-release/archive/release/humble/launch_pal/0.17.0-1.tar.gz";
+    name = "0.17.0-1.tar.gz";
+    sha256 = "0f23d2c4a56c8da8584ab55a9b6acbb11c9c243ae63ed9cbfbb02065be23ff1e";
   };
 
   buildType = "ament_python";

--- a/distros/humble/mapviz-interfaces/default.nix
+++ b/distros/humble/mapviz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-mapviz-interfaces";
-  version = "2.5.9-r1";
+  version = "2.5.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz_interfaces/2.5.9-1.tar.gz";
-    name = "2.5.9-1.tar.gz";
-    sha256 = "b90f91e6dca2b9f66d0b4a32c45ef8ba46b57bc6081a0aca0c931ed50e6d8ae7";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz_interfaces/2.5.10-1.tar.gz";
+    name = "2.5.10-1.tar.gz";
+    sha256 = "e824dcd64e3d717d14cdd84df3e73fe43551651b110c50707515e5e3ec9ffdaa";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mapviz-plugins/default.nix
+++ b/distros/humble/mapviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, cv-bridge, geometry-msgs, gps-msgs, image-transport, map-msgs, mapviz, marti-common-msgs, marti-nav-msgs, marti-sensor-msgs, marti-visualization-msgs, nav-msgs, opencv, pluginlib, qt5, rclcpp, rclcpp-action, ros-environment, sensor-msgs, std-msgs, std-srvs, stereo-msgs, swri-image-util, swri-math-util, swri-route-util, swri-transform-util, tf2, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-mapviz-plugins";
-  version = "2.5.9-r1";
+  version = "2.5.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz_plugins/2.5.9-1.tar.gz";
-    name = "2.5.9-1.tar.gz";
-    sha256 = "344a123dbfbcaed103ca38abbf39ec41d3e5bf3d9b4112069c070bbd027c4172";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz_plugins/2.5.10-1.tar.gz";
+    name = "2.5.10-1.tar.gz";
+    sha256 = "224681ebc089e7b88ee6c3544cff6fd153a1a3343818eaf863601af22efa2f3a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mapviz/default.nix
+++ b/distros/humble/mapviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, freeglut, geometry-msgs, glew, image-transport, mapviz-interfaces, opencv, pkg-config, pluginlib, qt5, rclcpp, ros-environment, rqt-gui, rqt-gui-cpp, std-srvs, swri-math-util, swri-transform-util, tf2, tf2-geometry-msgs, tf2-ros, xorg, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-mapviz";
-  version = "2.5.9-r1";
+  version = "2.5.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz/2.5.9-1.tar.gz";
-    name = "2.5.9-1.tar.gz";
-    sha256 = "0620238298b2966e1ac7d08d1f19d0dd291da34587a6a60d1ff0b0541a6bc500";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz/2.5.10-1.tar.gz";
+    name = "2.5.10-1.tar.gz";
+    sha256 = "61a7aad6aff0b8abc4973f56aa70dd7e4f2a5c181daf712e851d11f05ccba15d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/multires-image/default.nix
+++ b/distros/humble/multires-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, mapviz, pluginlib, qt5, rclcpp, rclpy, swri-math-util, swri-transform-util, tf2 }:
 buildRosPackage {
   pname = "ros-humble-multires-image";
-  version = "2.5.9-r1";
+  version = "2.5.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/multires_image/2.5.9-1.tar.gz";
-    name = "2.5.9-1.tar.gz";
-    sha256 = "a1953806967c928a1806e4fff5ff5762f63442fd365a5b434c4279dc79eb8a66";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/multires_image/2.5.10-1.tar.gz";
+    name = "2.5.10-1.tar.gz";
+    sha256 = "cb7a663aa9546ad53532b1f4bf06063b5121371695772998964467f517a6d3bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tile-map/default.nix
+++ b/distros/humble/tile-map/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, glew, jsoncpp, mapviz, pluginlib, qt5, rclcpp, swri-math-util, swri-transform-util, tf2, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-tile-map";
-  version = "2.5.9-r1";
+  version = "2.5.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/tile_map/2.5.9-1.tar.gz";
-    name = "2.5.9-1.tar.gz";
-    sha256 = "c3ac58189f3c6046d0d558d40c32bb5e5afb013383707792342989fcf91ad422";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/tile_map/2.5.10-1.tar.gz";
+    name = "2.5.10-1.tar.gz";
+    sha256 = "996d5ee23c88b5f0dbfb866ff9a79460849001eea3a13a77be65905d1765e37a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/async-web-server-cpp/default.nix
+++ b/distros/jazzy/async-web-server-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, boost, launch-testing, openssl, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-async-web-server-cpp";
-  version = "2.0.0-r6";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/async_web_server_cpp-release/archive/release/jazzy/async_web_server_cpp/2.0.0-6.tar.gz";
-    name = "2.0.0-6.tar.gz";
-    sha256 = "40fb602903b7cf0c68edeaacbe32046843b209dacb9537ba5b055bc5c1471b8b";
+    url = "https://github.com/ros2-gbp/async_web_server_cpp-release/archive/release/jazzy/async_web_server_cpp/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "ed7e9475f0daa00de6489040f9632878487a91dd48a2586edb7bd35cb6056227";
   };
 
   buildType = "catkin";

--- a/distros/jazzy/automatika-embodied-agents/default.nix
+++ b/distros/jazzy/automatika-embodied-agents/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, automatika-ros-sugar, builtin-interfaces, python3Packages, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-automatika-embodied-agents";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/automatika_embodied_agents-release/archive/release/jazzy/automatika_embodied_agents/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "ac4659024ed67ba3e480e4c8401f9cd5f29e5717f4116ebe5faccdc74d16f6ea";
+    url = "https://github.com/ros2-gbp/automatika_embodied_agents-release/archive/release/jazzy/automatika_embodied_agents/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "db8ef028f76d4fed35793e81209be008096d5817d4d7b0e2cd8f9b26965dd5de";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gz-tools-vendor/default.nix
+++ b/distros/jazzy/gz-tools-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, ruby }:
 buildRosPackage {
   pname = "ros-jazzy-gz-tools-vendor";
-  version = "0.0.6-r1";
+  version = "0.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_tools_vendor-release/archive/release/jazzy/gz_tools_vendor/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "29522541ec91bf9d196752360f1f38f237f1bd58f26240f6995f49631c21fc43";
+    url = "https://github.com/ros2-gbp/gz_tools_vendor-release/archive/release/jazzy/gz_tools_vendor/0.0.7-1.tar.gz";
+    name = "0.0.7-1.tar.gz";
+    sha256 = "5e681ed7dc3950c586f48b260f66c8fea5046b8537fef4c13cd92e473d2f514d";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-tools2 2.0.2
+    description = "Vendor package for: gz-tools2 2.0.3
 
     Gazebo Tools: Entrypoint to Gazebo's command line interface";
     license = with lib.licenses; [ asl20 ];

--- a/distros/jazzy/mapviz-interfaces/default.nix
+++ b/distros/jazzy/mapviz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-mapviz-interfaces";
-  version = "2.5.9-r1";
+  version = "2.5.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/mapviz_interfaces/2.5.9-1.tar.gz";
-    name = "2.5.9-1.tar.gz";
-    sha256 = "2364f9d6df4c1d41e8cb7ff801bb750f155671d9245f5386b336ebd0d14f4df8";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/mapviz_interfaces/2.5.10-1.tar.gz";
+    name = "2.5.10-1.tar.gz";
+    sha256 = "da164dc82328981c4f99f10e75d71c081e491b06e322cf77a1fefaa61f497286";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mapviz-plugins/default.nix
+++ b/distros/jazzy/mapviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, cv-bridge, geometry-msgs, gps-msgs, image-transport, map-msgs, mapviz, marti-common-msgs, marti-nav-msgs, marti-sensor-msgs, marti-visualization-msgs, nav-msgs, opencv, pluginlib, qt5, rclcpp, rclcpp-action, ros-environment, sensor-msgs, std-msgs, std-srvs, stereo-msgs, swri-image-util, swri-math-util, swri-route-util, swri-transform-util, tf2, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mapviz-plugins";
-  version = "2.5.9-r1";
+  version = "2.5.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/mapviz_plugins/2.5.9-1.tar.gz";
-    name = "2.5.9-1.tar.gz";
-    sha256 = "f5532d438dd75d3be21293033f7c5093a73fca56871058ceb7e1f48300e79e48";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/mapviz_plugins/2.5.10-1.tar.gz";
+    name = "2.5.10-1.tar.gz";
+    sha256 = "5c32a78b9d0aa1c3d40b348c40849d0a9361df3a93a4ce8a1e1456a256982485";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mapviz/default.nix
+++ b/distros/jazzy/mapviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, freeglut, geometry-msgs, glew, image-transport, mapviz-interfaces, opencv, pkg-config, pluginlib, qt5, rclcpp, ros-environment, rqt-gui, rqt-gui-cpp, std-srvs, swri-math-util, swri-transform-util, tf2, tf2-geometry-msgs, tf2-ros, xorg, yaml-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-mapviz";
-  version = "2.5.9-r1";
+  version = "2.5.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/mapviz/2.5.9-1.tar.gz";
-    name = "2.5.9-1.tar.gz";
-    sha256 = "da4eb074b94f1bcadb648aa62cd67d011a866a2a62c69d7600c1c4d5a84a40c7";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/mapviz/2.5.10-1.tar.gz";
+    name = "2.5.10-1.tar.gz";
+    sha256 = "6bdc394e89590ac7d77785f4359104cce169deb1093a04085b3bd7c8bc6fed39";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/multires-image/default.nix
+++ b/distros/jazzy/multires-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, mapviz, pluginlib, qt5, rclcpp, rclpy, swri-math-util, swri-transform-util, tf2 }:
 buildRosPackage {
   pname = "ros-jazzy-multires-image";
-  version = "2.5.9-r1";
+  version = "2.5.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/multires_image/2.5.9-1.tar.gz";
-    name = "2.5.9-1.tar.gz";
-    sha256 = "dbd61d6d581984bbb00b1d98957f8bf647306a27949813326e4bec37a5ba9dfb";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/multires_image/2.5.10-1.tar.gz";
+    name = "2.5.10-1.tar.gz";
+    sha256 = "4f567bba69182aa92cd6f0e7e1829bc95a5711fc9ace5998043bc1e6f2793562";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tile-map/default.nix
+++ b/distros/jazzy/tile-map/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, glew, jsoncpp, mapviz, pluginlib, qt5, rclcpp, swri-math-util, swri-transform-util, tf2, yaml-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-tile-map";
-  version = "2.5.9-r1";
+  version = "2.5.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/tile_map/2.5.9-1.tar.gz";
-    name = "2.5.9-1.tar.gz";
-    sha256 = "275718d9594a04e672779ee0f8209fb3f9824420d5d9ce047512574e242c5c68";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/jazzy/tile_map/2.5.10-1.tar.gz";
+    name = "2.5.10-1.tar.gz";
+    sha256 = "ac290184b6c90c8e8290eec01acd3c105f6a4b9e039043b4142679c661ad328b";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/async-web-server-cpp/default.nix
+++ b/distros/kilted/async-web-server-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, boost, launch-testing, openssl, python3Packages }:
 buildRosPackage {
   pname = "ros-kilted-async-web-server-cpp";
-  version = "2.0.0-r6";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/async_web_server_cpp-release/archive/release/kilted/async_web_server_cpp/2.0.0-6.tar.gz";
-    name = "2.0.0-6.tar.gz";
-    sha256 = "ac39cf39cb405341d3450a432b9d2db1a7b4331c52361e60446a2a05fed6ed2b";
+    url = "https://github.com/ros2-gbp/async_web_server_cpp-release/archive/release/kilted/async_web_server_cpp/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "aca33bff93fc594339358ee8975ada2703104bfbc6b5c2d2135e21364be8a53a";
   };
 
   buildType = "catkin";

--- a/distros/kilted/automatika-embodied-agents/default.nix
+++ b/distros/kilted/automatika-embodied-agents/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, automatika-ros-sugar, builtin-interfaces, python3Packages, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kilted-automatika-embodied-agents";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/automatika_embodied_agents-release/archive/release/kilted/automatika_embodied_agents/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "0152500e5b78e41089e970e8050fd8ed702a2fdcdfedaacfaf507abb890280a4";
+    url = "https://github.com/ros2-gbp/automatika_embodied_agents-release/archive/release/kilted/automatika_embodied_agents/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "4ac0d3702fbe4adf42a85a71d2e4ec5c052920563b1da20ba31c8bca1ce16d91";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/depthai-bridge/default.nix
+++ b/distros/kilted/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-info-manager, composition-interfaces, cv-bridge, depthai, depthai-ros-msgs, ffmpeg-image-transport-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-kilted-depthai-bridge";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_bridge/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "d3cb5a54bedf2e4d017c4425b042afedb1a993669a500ae3c7d994d42c3e7f80";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_bridge/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "5ce324c5b95bbe95dc60e4b20048dab745b55b3f8a40be214aad869a3391d3c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/depthai-descriptions/default.nix
+++ b/distros/kilted/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-kilted-depthai-descriptions";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_descriptions/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "6f331eaac849fb0abe3d8b7794620acdbfbf953bfbb1a89e48fc46abba353f7a";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_descriptions/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "5be9d3f284dc038680014991a3dfbc43c75517fdd67cd62a0ff843d41bd6b3df";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/depthai-examples/default.nix
+++ b/distros/kilted/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, backward-ros, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-kilted-depthai-examples";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_examples/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "5dee2caf299900a4875de36085d32c2607023700b5dc3506208a870f16586ccd";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_examples/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "6744f7a5b300190e166acc282559ec14bba4a19ace24a52b01de7d5facfa4d38";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/depthai-filters/default.nix
+++ b/distros/kilted/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, depthai-ros-msgs, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-depthai-filters";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_filters/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "789cb307c28b4549a79379c6ce3c34712f5657d2eaebbe5f7c8030aed1e1200a";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_filters/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "24022bc08dd7aed0b7dc7510aa84a82b6c18982f6599ad17e97ce3605e6e083f";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/depthai-ros-driver/default.nix
+++ b/distros/kilted/depthai-ros-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, camera-info-manager, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, ffmpeg-image-transport-msgs, image-pipeline, image-transport, image-transport-plugins, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-kilted-depthai-ros-driver";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_ros_driver/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "43a804b99553c052271e8b69a167d984e6376e46e223aa4f1ddb9cb9710ede58";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_ros_driver/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "f99a3e37d7d3f1fb9363de61285b2d3659c789bc0dabccb89ab0871d845dd35a";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/depthai-ros-msgs/default.nix
+++ b/distros/kilted/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-kilted-depthai-ros-msgs";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_ros_msgs/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "6e2a45ad3ddb41b362c405345d8829129c90ff7e04549f6cf1e54b6b8eee5768";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai_ros_msgs/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "d966573098784df440199a78b10e34572c706f86254fa726fce74cde53c89ae5";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/depthai-ros/default.nix
+++ b/distros/kilted/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-kilted-depthai-ros";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai-ros/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "0bb5369effc29a281d103a3151a78b6ae2b05d687b3a24b9c7ed8339f0d655b2";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/kilted/depthai-ros/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "7a5b57a267beb71709663963fff3e5cdfb8242fc6c66a186f446fe02e5426d46";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/depthai/default.nix
+++ b/distros/kilted/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, curl, libtar, libusb1, nlohmann_json, opencv, ros-environment, udev, unzip, zip }:
 buildRosPackage {
   pname = "ros-kilted-depthai";
-  version = "3.0.3-r1";
+  version = "3.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/kilted/depthai/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "1bc7ea1ce73d0380f6beaee864221af32a71e3fd2471409129a4d8b9bdf94e2e";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/kilted/depthai/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "5081413da7ea72bba54ab3881c9b61b960d1c160810ef46b01f5c5aec1e82a86";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/gz-common-vendor/default.nix
+++ b/distros/kilted/gz-common-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, assimp, cmake, ffmpeg, freeimage, gdal, gz-cmake-vendor, gz-math-vendor, gz-utils-vendor, pkg-config, spdlog-vendor, tinyxml-2, util-linux }:
 buildRosPackage {
   pname = "ros-kilted-gz-common-vendor";
-  version = "0.2.3-r2";
+  version = "0.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_common_vendor-release/archive/release/kilted/gz_common_vendor/0.2.3-2.tar.gz";
-    name = "0.2.3-2.tar.gz";
-    sha256 = "cfbc8db6014b528a687edf3c92b6de0d78cf51ca20b3898d72e4ba1007dfc3a1";
+    url = "https://github.com/ros2-gbp/gz_common_vendor-release/archive/release/kilted/gz_common_vendor/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "07fae9488afe0647234b4793191c8ee5eec49a72cc48ac6f9177e8709c6aafd9";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake pkg-config ];
 
   meta = {
-    description = "Vendor package for: gz-common6 6.0.2
+    description = "Vendor package for: gz-common6 6.1.0
 
     Gazebo Common : AV, Graphics, Events, and much more.";
     license = with lib.licenses; [ asl20 ];

--- a/distros/kilted/gz-fuel-tools-vendor/default.nix
+++ b/distros/kilted/gz-fuel-tools-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, curl, gflags, gz-cmake-vendor, gz-common-vendor, gz-math-vendor, gz-msgs-vendor, gz-tools-vendor, gz-utils-vendor, jsoncpp, libyaml, libzip, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-kilted-gz-fuel-tools-vendor";
-  version = "0.2.1-r2";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_fuel_tools_vendor-release/archive/release/kilted/gz_fuel_tools_vendor/0.2.1-2.tar.gz";
-    name = "0.2.1-2.tar.gz";
-    sha256 = "8d4d931d1e806bfb07329270f55e54364080f5895dc008260668244e5816272f";
+    url = "https://github.com/ros2-gbp/gz_fuel_tools_vendor-release/archive/release/kilted/gz_fuel_tools_vendor/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "121e3c8f64262ad931e3fdb50192554dc9e747abc337a21e76945184cadc7967";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-fuel_tools10 10.0.1
+    description = "Vendor package for: gz-fuel_tools10 10.1.0
 
     Gazebo Fuel Tools: Classes and tools for interacting with Gazebo Fuel";
     license = with lib.licenses; [ asl20 ];

--- a/distros/kilted/gz-math-vendor/default.nix
+++ b/distros/kilted/gz-math-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, eigen, gz-cmake-vendor, gz-utils-vendor, python3Packages }:
 buildRosPackage {
   pname = "ros-kilted-gz-math-vendor";
-  version = "0.2.3-r2";
+  version = "0.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_math_vendor-release/archive/release/kilted/gz_math_vendor/0.2.3-2.tar.gz";
-    name = "0.2.3-2.tar.gz";
-    sha256 = "575ca0af08261a398464c1f121fd61900e89ad73658de749fcdd18d694e3de51";
+    url = "https://github.com/ros2-gbp/gz_math_vendor-release/archive/release/kilted/gz_math_vendor/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "11e4296c9c7cf5c9c27de0e0551bd8f37464eaece0eec18910d574e3db876faa";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-math8 8.1.1
+    description = "Vendor package for: gz-math8 8.2.0
 
     Gazebo Math : Math classes and functions for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/kilted/gz-physics-vendor/default.nix
+++ b/distros/kilted/gz-physics-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, bullet, cmake, eigen, gbenchmark, gz-cmake-vendor, gz-common-vendor, gz-dartsim-vendor, gz-math-vendor, gz-plugin-vendor, gz-utils-vendor, sdformat-vendor }:
 buildRosPackage {
   pname = "ros-kilted-gz-physics-vendor";
-  version = "0.2.1-r2";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_physics_vendor-release/archive/release/kilted/gz_physics_vendor/0.2.1-2.tar.gz";
-    name = "0.2.1-2.tar.gz";
-    sha256 = "d980bce92934466e21cffa9ae4d676af4d67e238aea1e35a41b9de1a4b043562";
+    url = "https://github.com/ros2-gbp/gz_physics_vendor-release/archive/release/kilted/gz_physics_vendor/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "d9116d8635162f3d9235880393f2e3683abcf6c90295f1197a921f937d35c3ac";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-physics8 8.1.0
+    description = "Vendor package for: gz-physics8 8.3.0
 
     Gazebo Physics : Physics classes and functions for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/kilted/gz-rendering-vendor/default.nix
+++ b/distros/kilted/gz-rendering-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, freeglut, freeimage, glew, gz-cmake-vendor, gz-common-vendor, gz-math-vendor, gz-ogre-next-vendor, gz-plugin-vendor, gz-utils-vendor, ogre1_9, util-linux, vulkan-loader, xorg }:
 buildRosPackage {
   pname = "ros-kilted-gz-rendering-vendor";
-  version = "0.2.1-r2";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_rendering_vendor-release/archive/release/kilted/gz_rendering_vendor/0.2.1-2.tar.gz";
-    name = "0.2.1-2.tar.gz";
-    sha256 = "71360aa4d8ecab6dee85fa287cc095fb192500d342f8e5945638c8b33c96602e";
+    url = "https://github.com/ros2-gbp/gz_rendering_vendor-release/archive/release/kilted/gz_rendering_vendor/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "5ef41e8378fc4030cda830919427923cbc7bf89096d53a63c606c15e655f55d4";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-rendering9 9.1.0
+    description = "Vendor package for: gz-rendering9 9.3.0
 
     Gazebo Rendering: Rendering library for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/kilted/gz-sensors-vendor/default.nix
+++ b/distros/kilted/gz-sensors-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, gz-common-vendor, gz-math-vendor, gz-msgs-vendor, gz-rendering-vendor, gz-tools-vendor, gz-transport-vendor, sdformat-vendor, xorg }:
 buildRosPackage {
   pname = "ros-kilted-gz-sensors-vendor";
-  version = "0.2.1-r2";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_sensors_vendor-release/archive/release/kilted/gz_sensors_vendor/0.2.1-2.tar.gz";
-    name = "0.2.1-2.tar.gz";
-    sha256 = "6ad0684533dc8a85427aa35ab461cc2cf0cb58918a106aa71f4dbe38f7fef2e0";
+    url = "https://github.com/ros2-gbp/gz_sensors_vendor-release/archive/release/kilted/gz_sensors_vendor/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "4a215e3d2c2432921debf8e0aa34b1bbae3fe38a4a0a69f9f052dbcada0c0779";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-sensors9 9.1.0
+    description = "Vendor package for: gz-sensors9 9.2.0
 
     Gazebo Sensors : Sensor models for simulation";
     license = with lib.licenses; [ asl20 ];

--- a/distros/kilted/gz-tools-vendor/default.nix
+++ b/distros/kilted/gz-tools-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, ruby }:
 buildRosPackage {
   pname = "ros-kilted-gz-tools-vendor";
-  version = "0.1.2-r2";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_tools_vendor-release/archive/release/kilted/gz_tools_vendor/0.1.2-2.tar.gz";
-    name = "0.1.2-2.tar.gz";
-    sha256 = "c3f6aba1412c320302dbb9caf278ac430342c190b4ed0ea8cc1618b3dbca9aa9";
+    url = "https://github.com/ros2-gbp/gz_tools_vendor-release/archive/release/kilted/gz_tools_vendor/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "9385936ceef9a71e0585f7964ef729235bb99e5d421aea53382ad487f106dccb";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-tools2 2.0.2
+    description = "Vendor package for: gz-tools2 2.0.3
 
     Gazebo Tools: Entrypoint to Gazebo's command line interface";
     license = with lib.licenses; [ asl20 ];

--- a/distros/kilted/mapviz-interfaces/default.nix
+++ b/distros/kilted/mapviz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-kilted-mapviz-interfaces";
-  version = "2.5.9-r1";
+  version = "2.5.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/mapviz_interfaces/2.5.9-1.tar.gz";
-    name = "2.5.9-1.tar.gz";
-    sha256 = "c9c6a57f905c11e36b62589e5ce5b3cfba5e00f73315c2b5535a3794765ebe01";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/mapviz_interfaces/2.5.10-1.tar.gz";
+    name = "2.5.10-1.tar.gz";
+    sha256 = "b3ff2d6cb1c054119583bff166eb0ee48637cd5aa5865bcfcfe6c3c95cbf456c";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mapviz-plugins/default.nix
+++ b/distros/kilted/mapviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, cv-bridge, geometry-msgs, gps-msgs, image-transport, map-msgs, mapviz, marti-common-msgs, marti-nav-msgs, marti-sensor-msgs, marti-visualization-msgs, nav-msgs, opencv, pluginlib, qt5, rclcpp, rclcpp-action, ros-environment, sensor-msgs, std-msgs, std-srvs, stereo-msgs, swri-image-util, swri-math-util, swri-route-util, swri-transform-util, tf2, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kilted-mapviz-plugins";
-  version = "2.5.9-r1";
+  version = "2.5.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/mapviz_plugins/2.5.9-1.tar.gz";
-    name = "2.5.9-1.tar.gz";
-    sha256 = "ad309c3db68dcfb3622af39451e081218825e792142c8e7515d635c8ea64be0a";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/mapviz_plugins/2.5.10-1.tar.gz";
+    name = "2.5.10-1.tar.gz";
+    sha256 = "8eba813ccb6ae5857430e500b229891eb8bbe63cdfe639a572f8d1954ada5665";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/mapviz/default.nix
+++ b/distros/kilted/mapviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, freeglut, geometry-msgs, glew, image-transport, mapviz-interfaces, opencv, pkg-config, pluginlib, qt5, rclcpp, ros-environment, rqt-gui, rqt-gui-cpp, std-srvs, swri-math-util, swri-transform-util, tf2, tf2-geometry-msgs, tf2-ros, xorg, yaml-cpp }:
 buildRosPackage {
   pname = "ros-kilted-mapviz";
-  version = "2.5.9-r1";
+  version = "2.5.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/mapviz/2.5.9-1.tar.gz";
-    name = "2.5.9-1.tar.gz";
-    sha256 = "59f63f2440b3da65ccfb4a51f748d8c0ebbb1af879fac0c12fe36b59dd6c16bd";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/mapviz/2.5.10-1.tar.gz";
+    name = "2.5.10-1.tar.gz";
+    sha256 = "c30720cb7addd762520e01e6f61324c13fc25ca39055c688849f51d727940446";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/multires-image/default.nix
+++ b/distros/kilted/multires-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, mapviz, pluginlib, qt5, rclcpp, rclpy, swri-math-util, swri-transform-util, tf2 }:
 buildRosPackage {
   pname = "ros-kilted-multires-image";
-  version = "2.5.9-r1";
+  version = "2.5.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/multires_image/2.5.9-1.tar.gz";
-    name = "2.5.9-1.tar.gz";
-    sha256 = "380e54b41c3217bcde1465418e8cba156e5f5203a1b71100f5e26287e043de02";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/multires_image/2.5.10-1.tar.gz";
+    name = "2.5.10-1.tar.gz";
+    sha256 = "54bdff9df799e054aadef1b1b3a65c2a1fd743a9c63e060762f2ead4f9fd6405";
   };
 
   buildType = "ament_cmake";

--- a/distros/kilted/tile-map/default.nix
+++ b/distros/kilted/tile-map/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, glew, jsoncpp, mapviz, pluginlib, qt5, rclcpp, swri-math-util, swri-transform-util, tf2, yaml-cpp }:
 buildRosPackage {
   pname = "ros-kilted-tile-map";
-  version = "2.5.9-r1";
+  version = "2.5.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/tile_map/2.5.9-1.tar.gz";
-    name = "2.5.9-1.tar.gz";
-    sha256 = "3e2100ca2fbabe204fbc6490b19fea5e72ef303d4c8221b70c24891bc12bc8ef";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/kilted/tile_map/2.5.10-1.tar.gz";
+    name = "2.5.10-1.tar.gz";
+    sha256 = "9ea504b09b934afd78398268456eb9580acd6ed38eea83d5fa3fde9cbecffb22";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ackermann-steering-controller/default.nix
+++ b/distros/rolling/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-ackermann-steering-controller";
-  version = "5.5.0-r1";
+  version = "5.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "d0fb70368aa8d11c519802a601b996c16a21dcd361453515b4d22b32bb43ab4b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "b7825c50dade14510c22ee34d609f28991f4910f5a43896274a61a618456ecdb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/admittance-controller/default.nix
+++ b/distros/rolling/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-admittance-controller";
-  version = "5.5.0-r1";
+  version = "5.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "4eba39cff237b5cca50e7399f8f4768de9d8818cf1c8e5342df56b6fa8cb9f31";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "a4865fc87b2d7918c73049cb573774cdefa5d57a4623aef60c73aba6903943a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/apriltag-detector-mit/default.nix
+++ b/distros/rolling/apriltag-detector-mit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, apriltag-detector, apriltag-mit, apriltag-msgs, pluginlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-apriltag-detector-mit";
-  version = "3.0.3-r1";
+  version = "3.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/rolling/apriltag_detector_mit/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "7e242a91b9186aa97bb7093c7acc81aad0a6e6dfa8b68f4a4a598d4055d25b42";
+    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/rolling/apriltag_detector_mit/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "e63ead4759b1d88b57e97904f10ff4e1cc8ddeb39925a54366072c504f5e0ca7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/apriltag-detector-umich/default.nix
+++ b/distros/rolling/apriltag-detector-umich/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, apriltag, apriltag-detector, apriltag-msgs, opencv, pluginlib, rclcpp, ros-environment, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-apriltag-detector-umich";
-  version = "3.0.3-r1";
+  version = "3.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/rolling/apriltag_detector_umich/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "8dcc154cca912cef996a50c2273240304603cd252f72f5ba6e624bc2521424df";
+    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/rolling/apriltag_detector_umich/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "956c7a826e8dcc4265c673f5552c17d5e90c604366e0c55ad54448698bf0a9cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/apriltag-detector/default.nix
+++ b/distros/rolling/apriltag-detector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, apriltag-msgs, cv-bridge, image-transport, pluginlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-apriltag-detector";
-  version = "3.0.3-r1";
+  version = "3.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/rolling/apriltag_detector/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "ba4bd68ca5e007f941711c49ce31c0d229a7c832307962b08210edc0ec7da876";
+    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/rolling/apriltag_detector/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "ad76ba44550e0a06d63d181b1ff5aaead07ce3fa57d4f2c153773ee0b7f4e71d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/apriltag-draw/default.nix
+++ b/distros/rolling/apriltag-draw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, apriltag-msgs, cv-bridge, image-transport, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-apriltag-draw";
-  version = "3.0.3-r1";
+  version = "3.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/rolling/apriltag_draw/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "71965b78050748a1ba1f880c405179876e1786c5f4184c8a25b44ca9e60d6ead";
+    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/rolling/apriltag_draw/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "ee0830454d243052d64c4a13fccc39328b869353fd9e71ea1d9f1ac930129465";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/apriltag-ros/default.nix
+++ b/distros/rolling/apriltag-ros/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-lint-auto, apriltag, apriltag-msgs, cv-bridge, eigen, image-transport, rclcpp, rclcpp-components, sensor-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-lint-auto, apriltag, apriltag-msgs, camera-ros, clang, cv-bridge, eigen, image-proc, image-transport, image-transport-plugins, rclcpp, rclcpp-components, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-apriltag-ros";
-  version = "3.2.2-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag_ros-release/archive/release/rolling/apriltag_ros/3.2.2-1.tar.gz";
-    name = "3.2.2-1.tar.gz";
-    sha256 = "0fd136c55e81849b1758e7603c20421f52471ea750575eca643f06c96b9585eb";
+    url = "https://github.com/ros2-gbp/apriltag_ros-release/archive/release/rolling/apriltag_ros/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "890e821bff7369d5e7608b2f9dbcf44a22b699e7b7e7abdfb97f07ae2dc79039";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake eigen ];
-  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-lint-auto ];
-  propagatedBuildInputs = [ apriltag apriltag-msgs cv-bridge image-transport rclcpp rclcpp-components sensor-msgs tf2-ros ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-lint-auto clang ];
+  propagatedBuildInputs = [ apriltag apriltag-msgs camera-ros cv-bridge image-proc image-transport image-transport-plugins rclcpp rclcpp-components sensor-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/apriltag-tools/default.nix
+++ b/distros/rolling/apriltag-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, apriltag-detector, apriltag-draw, apriltag-msgs, rclcpp, ros-environment, rosbag2-transport }:
 buildRosPackage {
   pname = "ros-rolling-apriltag-tools";
-  version = "3.0.3-r1";
+  version = "3.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/rolling/apriltag_tools/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "e8535fc9edbda3fbeb3c20c4a023d5eab57add845d340fd4adc16f9cc2bfc59b";
+    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/rolling/apriltag_tools/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "530b5ca90094dfa4e0239ab3bc0834430eefd7704c012824154da17555ce64bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/apriltag/default.nix
+++ b/distros/rolling/apriltag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, opencv, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-apriltag";
-  version = "3.4.4-r1";
+  version = "3.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag-release/archive/release/rolling/apriltag/3.4.4-1.tar.gz";
-    name = "3.4.4-1.tar.gz";
-    sha256 = "4f93ebac01844301b97b9a5ccbbdc5e24c1c1322808a86f3257ec3cb28558fdf";
+    url = "https://github.com/ros2-gbp/apriltag-release/archive/release/rolling/apriltag/3.4.5-1.tar.gz";
+    name = "3.4.5-1.tar.gz";
+    sha256 = "c12d9989095cfa92423c319697eb3b2de3788d1411d58d0cbb1f3a0695fc0150";
   };
 
   buildType = "cmake";

--- a/distros/rolling/async-web-server-cpp/default.nix
+++ b/distros/rolling/async-web-server-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, boost, launch-testing, openssl, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-async-web-server-cpp";
-  version = "2.0.0-r5";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/async_web_server_cpp-release/archive/release/rolling/async_web_server_cpp/2.0.0-5.tar.gz";
-    name = "2.0.0-5.tar.gz";
-    sha256 = "f5cae168769df2e30d2c2bae30b9a28ec8560116c6b376ad573a7cbf8d10b488";
+    url = "https://github.com/ros2-gbp/async_web_server_cpp-release/archive/release/rolling/async_web_server_cpp/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "12e0f8fd253f5d65aa7248c793eb20802c22013fc8a42414adca4cd189d8e2ce";
   };
 
   buildType = "catkin";

--- a/distros/rolling/at-sonde-ros-driver/default.nix
+++ b/distros/rolling/at-sonde-ros-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, libmodbus, rclcpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-at-sonde-ros-driver";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/at_sonde_ros_driver-release/archive/release/rolling/at_sonde_ros_driver/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "d62c9bba5cc86ea13e7ecf7a9d0735604fc0ec43b1ba63b2f8bb42a571dbb646";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ libmodbus rclcpp std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A ROS 2 driver to stream the monitored parameters of an In-Situ Aqua TROLL Multiparameter Sonde.";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/rolling/automatika-embodied-agents/default.nix
+++ b/distros/rolling/automatika-embodied-agents/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, automatika-ros-sugar, builtin-interfaces, python3Packages, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-automatika-embodied-agents";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/automatika_embodied_agents-release/archive/release/rolling/automatika_embodied_agents/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "52e8db27af07684ae4dc29ed2bd53b43ff7219b875ba327ae24cc0c8b8c31cdd";
+    url = "https://github.com/ros2-gbp/automatika_embodied_agents-release/archive/release/rolling/automatika_embodied_agents/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "055fb49a57a2963795b0f7dff62644dcaa31a7899db78dca385eacd025dc64db";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/automatika-ros-sugar/default.nix
+++ b/distros/rolling/automatika-ros-sugar/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-index-python, ament-lint-auto, builtin-interfaces, geometry-msgs, launch, launch-testing, lifecycle-msgs, nav-msgs, python3Packages, rclcpp, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-automatika-ros-sugar";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/automatika_ros_sugar-release/archive/release/rolling/automatika_ros_sugar/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "2ca4c69f8fa0d8dcab791f30e45424b318b5214fb1c8d111dd548041012dd71d";
+    url = "https://github.com/ros2-gbp/automatika_ros_sugar-release/archive/release/rolling/automatika_ros_sugar/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "9a196c47fbd3ed518277854bdf848ae9f6af106162105d0497841139fd15d20d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/bicycle-steering-controller/default.nix
+++ b/distros/rolling/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-bicycle-steering-controller";
-  version = "5.5.0-r1";
+  version = "5.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "ffa55582409e2219bfebaf1d56cb1d76f3636117a2b9c22859d0d035c773cd9a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "d12c27b9576460fadf5fae2781fce2d1be6db2aa8f8b5707c6db0a1310719274";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/camera-ros/default.nix
+++ b/distros/rolling/camera-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-pep257, ament-cmake-pyflakes, ament-cmake-xmllint, ament-index-python, ament-lint-auto, camera-info-manager, clang, cv-bridge, image-view, libcamera, rclcpp, rclcpp-components, ros2launch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-camera-ros";
-  version = "0.4.0-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/camera_ros-release/archive/release/rolling/camera_ros/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "e85bd872845595f1a36701e291dc6c22ed3079b6927644cf451593bb16f4c0be";
+    url = "https://github.com/ros2-gbp/camera_ros-release/archive/release/rolling/camera_ros/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "52e68632275b6eac76d0d320708326697831ffc8a891ef211e072b818df71324";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/catch-ros2/default.nix
+++ b/distros/rolling/catch-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, ros2launch, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-catch-ros2";
-  version = "0.2.1-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/catch_ros2-release/archive/release/rolling/catch_ros2/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "24484c01a58e4a228feee01c2035a3a4ce28ebe495313a0a602373bd14420f98";
+    url = "https://github.com/ros2-gbp/catch_ros2-release/archive/release/rolling/catch_ros2/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "ff321ae29c455098bd6387a9fac412924d0f358a09b88c2f8af56015f1e05066";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/chained-filter-controller/default.nix
+++ b/distros/rolling/chained-filter-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, filters, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets }:
+buildRosPackage {
+  pname = "ros-rolling-chained-filter-controller";
+  version = "5.6.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/chained_filter_controller/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "e3241bc0fe39e54505ab503da4691db39daf8269abadc188d2568588431232a9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake generate-parameter-library ros2-control-cmake ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
+  propagatedBuildInputs = [ controller-interface filters hardware-interface pluginlib rclcpp rclcpp-lifecycle ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ros2_controller for configuring filter chains";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/control-msgs/default.nix
+++ b/distros/rolling/control-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-control-msgs";
-  version = "6.4.0-r1";
+  version = "6.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_msgs-release/archive/release/rolling/control_msgs/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "f4fc19d254b31548c0c1d505d72728ad560c6ab0a1e2d70b27e02f9b5d20b49d";
+    url = "https://github.com/ros2-gbp/control_msgs-release/archive/release/rolling/control_msgs/6.5.0-1.tar.gz";
+    name = "6.5.0-1.tar.gz";
+    sha256 = "f871c0c751b9697e135667bc80e4eeff658d17b3970830e062d2d4b1d54495c8";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ action-msgs builtin-interfaces geometry-msgs rosidl-default-runtime sensor-msgs std-msgs trajectory-msgs ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces diagnostic-msgs geometry-msgs rosidl-default-runtime sensor-msgs std-msgs trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/rolling/controller-interface/default.nix
+++ b/distros/rolling/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, fmt, geometry-msgs, hardware-interface, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-interface";
-  version = "5.5.0-r1";
+  version = "5.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "3ae4794711e167fda8af0f22c2ffc50b3b55f4697460700d4d69bffece0e16fa";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/5.6.0-1.tar.gz";
+    name = "5.6.0-1.tar.gz";
+    sha256 = "4970d0de028429a69e05053dc6e6aa03f1781036a635ff745d77ebfa08c9a575";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager-msgs/default.nix
+++ b/distros/rolling/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager-msgs";
-  version = "5.5.0-r1";
+  version = "5.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "8e8e4a8626248f8f2645c323bd4b2f67080ff4de9ad63f1f99a7c370d29197a1";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/5.6.0-1.tar.gz";
+    name = "5.6.0-1.tar.gz";
+    sha256 = "4043bfb99a145de30e19e583992ea3f7c5b791e119ced8bda161a0117d0f4de9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager/default.nix
+++ b/distros/rolling/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, example-interfaces, fmt, generate-parameter-library, hardware-interface, hardware-interface-testing, launch, launch-ros, launch-testing, launch-testing-ros, libstatistics-collector, pluginlib, python3Packages, rclcpp, rclpy, rcpputils, realtime-tools, robot-state-publisher, ros2-control-cmake, ros2-control-test-assets, ros2param, ros2run, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager";
-  version = "5.5.0-r1";
+  version = "5.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "3ebfeb55e6b3154570053bc2773f0bfb49182b5ee4ba637f390e0ff2c6defd07";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/5.6.0-1.tar.gz";
+    name = "5.6.0-1.tar.gz";
+    sha256 = "0f049792325f0b6964bddfa23027a916bea447b04aae71f3810f9c7b05b5db80";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/diff-drive-controller/default.nix
+++ b/distros/rolling/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diff-drive-controller";
-  version = "5.5.0-r1";
+  version = "5.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "6746cbb509592e4873841266127b1a304a3da3d42da5eaba840a0b648100bb31";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "29c101dc951072935440b1fcde0b0fb44a4b06d6a55030a962da44512b6c26bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/effort-controllers/default.nix
+++ b/distros/rolling/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-effort-controllers";
-  version = "5.5.0-r1";
+  version = "5.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "6ad4ccb9722a34a78eeabfdcec8306dbf79b0ea388cb1678b32d395d63227b47";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "a6adcf37e45621d51b9b86348fe03d2f82bef6588dcbf52c52b44380d2928ded";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/event-camera-renderer/default.nix
+++ b/distros/rolling/event-camera-renderer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, event-camera-codecs, event-camera-msgs, image-transport, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-event-camera-renderer";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/event_camera_renderer-release/archive/release/rolling/event_camera_renderer/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "b1d7bb261d23054f56b34e355cddb18bf72368e8cb42be8ea71fe4e9ef2a7fd1";
+    url = "https://github.com/ros2-gbp/event_camera_renderer-release/archive/release/rolling/event_camera_renderer/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "37bcf33c61b9acc8f024b9875bc2b5a212f1928a01ac058743fd0436c4d0fbed";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-tf2-py/default.nix
+++ b/distros/rolling/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, launch-ros, python3Packages, rclpy, sensor-msgs, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-examples-tf2-py";
-  version = "0.44.0-r1";
+  version = "0.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/examples_tf2_py/0.44.0-1.tar.gz";
-    name = "0.44.0-1.tar.gz";
-    sha256 = "286d3b02d200eea1e67ccbccdad9d2135946a7a530a2693150bff593c6335e7e";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/examples_tf2_py/0.45.0-1.tar.gz";
+    name = "0.45.0-1.tar.gz";
+    sha256 = "82bc547d691a948dc28d0ad68bf72ee9d0f90dc967b6ef4600db8e4ce291ddf1";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ffmpeg-image-transport/default.nix
+++ b/distros/rolling/ffmpeg-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-clang-format, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ffmpeg-encoder-decoder, ffmpeg-image-transport-msgs, image-transport, pluginlib, rclcpp, rcutils, ros-environment, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ffmpeg-image-transport";
-  version = "3.0.0-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ffmpeg_image_transport-release/archive/release/rolling/ffmpeg_image_transport/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "a2145f15d2b369f25f8c38423b6292e141833b1d85b8ae9a38d69afa4c69c016";
+    url = "https://github.com/ros2-gbp/ffmpeg_image_transport-release/archive/release/rolling/ffmpeg_image_transport/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "6b78c6693e17689c35de78b25cb567e424d904cf2de597699792becdb9355c8a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/force-torque-sensor-broadcaster/default.nix
+++ b/distros/rolling/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-force-torque-sensor-broadcaster";
-  version = "5.5.0-r1";
+  version = "5.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "1cb981b9b5ded6624078b27d5252c9b271aa322602f7c2387b8e84e284a3e696";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "8540b22a14d53ea8adb052bc691f1b3953f4ffc0f1cd72f06af603d0b3f8549a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/forward-command-controller/default.nix
+++ b/distros/rolling/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-forward-command-controller";
-  version = "5.5.0-r1";
+  version = "5.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "34895fd831c2b7003c454307355677e39caa51d89e23a13da08e9434071310c6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "f6d5c0b93cfbc561be15fc600fe02a7314b06dd7d617897ed5bf4b27a5964aec";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/foxglove-compressed-video-transport/default.nix
+++ b/distros/rolling/foxglove-compressed-video-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ffmpeg-encoder-decoder, foxglove-msgs, image-transport, pluginlib, rclcpp, rcutils, ros-environment, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-foxglove-compressed-video-transport";
-  version = "3.0.0-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_compressed_video_transport-release/archive/release/rolling/foxglove_compressed_video_transport/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "cd3ae995fea2cb27ea7e5e4a3f13a91620ab50542fb1ef7fe8a7dfa61c6a1279";
+    url = "https://github.com/ros2-gbp/foxglove_compressed_video_transport-release/archive/release/rolling/foxglove_compressed_video_transport/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "9a8e4858fde8b61713304dfad721c989926e5915dc836c86f03634281a389da4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fuse-constraints/default.nix
+++ b/distros/rolling/fuse-constraints/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ceres-solver, eigen, fuse-core, fuse-graphs, fuse-variables, gbenchmark, geometry-msgs, gtest-vendor, pluginlib, rclcpp, suitesparse }:
 buildRosPackage {
   pname = "ros-rolling-fuse-constraints";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_constraints/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "e1bf4be4b710de24e90f294bbba8574fa9c8dafac0418855fec56915b8622530";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_constraints/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "b9b73fe2a8d2849ac8c11ba99f4cbec258d7ae53abf1f05fb59ca23a6cf090ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fuse-core/default.nix
+++ b/distros/rolling/fuse-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, boost, ceres-solver, eigen, fuse-msgs, geometry-msgs, glog, gtest-vendor, launch, launch-pytest, pluginlib, rcl-interfaces, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-rolling-fuse-core";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_core/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "fe8eba95e1bfc6020f541ea9cbd9515a00e33d7323891d26463d6ec42e1729b5";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_core/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "001d374e6827337ed13bd6da37e2e3ff5aacb8069087ef2bae186387c88da873";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fuse-doc/default.nix
+++ b/distros/rolling/fuse-doc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, gtest-vendor }:
 buildRosPackage {
   pname = "ros-rolling-fuse-doc";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_doc/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "7e1a83f573b4b652a556b3811169a22b9beeed86196b8fde1731279e57669167";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_doc/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "3c2001283a82c649cfc3afab3865e4bd82c9c74f3b922c656c3c0ec88aede027";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fuse-graphs/default.nix
+++ b/distros/rolling/fuse-graphs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ceres-solver, fuse-core, gbenchmark, gtest-vendor, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-fuse-graphs";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_graphs/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "037be98337eb8b02cde5a58d75c9113f098a1d6162cfc8ad3021e6c1880bd275";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_graphs/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "bbeea0550f0293c7d80c08714f0d02f37b5cf9c9598114639ef1aba6dd67a87b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fuse-loss/default.nix
+++ b/distros/rolling/fuse-loss/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ceres-solver, fuse-core, gtest-vendor, libsForQt5, pluginlib, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-fuse-loss";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_loss/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "a2bb5997821809f38be12dd4692a65b6c23197e8aaaa5572e73a3e753e848de1";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_loss/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "76b515780f3e417434dbf0bf7724bad7781780dc04c46ef21528e3da013f4c35";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fuse-models/default.nix
+++ b/distros/rolling/fuse-models/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, boost, ceres-solver, eigen, fuse-constraints, fuse-core, fuse-graphs, fuse-msgs, fuse-publishers, fuse-variables, gbenchmark, geometry-msgs, gtest-vendor, nav-msgs, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-srvs, tf2, tf2-2d, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-fuse-models";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_models/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "75b1d023a82a3402e984e7c20c22630e7331e7b92a43cc57e9480c29c0bdd70d";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_models/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "2d6bfead8afd2d8abd74ae82bca100746fc0d80d8f4b98291a3d80324cc87184";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fuse-msgs/default.nix
+++ b/distros/rolling/fuse-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, geometry-msgs, gtest-vendor, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-fuse-msgs";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_msgs/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "20726ffe5576e805d129eb81c6849eb87ff96a19d56374d2e7f11dd13b04c73f";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_msgs/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "273d45cb6cf27bd7fde459576015dd6aabcea8e98dccbf1d8591a1cf893e63a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fuse-optimizers/default.nix
+++ b/distros/rolling/fuse-optimizers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, boost, ceres-solver, diagnostic-updater, eigen, fuse-constraints, fuse-core, fuse-graphs, fuse-models, fuse-msgs, fuse-variables, geometry-msgs, gtest-vendor, launch, launch-pytest, launch-ros, nav-msgs, pluginlib, rclcpp, rclcpp-components, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-fuse-optimizers";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_optimizers/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "5e0d024e031747e32c92594c260a3ca6a6cc3e3a1bcd71b9e25fbe496d0d9295";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_optimizers/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "f474a31aa89528f5650bc58f32c15161c3a98af76280ad5e2e20e191f6fa2b00";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fuse-publishers/default.nix
+++ b/distros/rolling/fuse-publishers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fuse-constraints, fuse-core, fuse-graphs, fuse-msgs, fuse-variables, geometry-msgs, gtest-vendor, nav-msgs, pluginlib, rclcpp, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-fuse-publishers";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_publishers/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "e6c43074ec842938db8f6a3ba4b34d9daed704250f21c1fda8028ed6d17a4bfe";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_publishers/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "e9d6c9546273e2d6aa574b2b74df8b7817d47798cd1fd59df9d9305998a53772";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fuse-tutorials/default.nix
+++ b/distros/rolling/fuse-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fuse-constraints, fuse-core, fuse-models, fuse-optimizers, fuse-publishers, fuse-variables, gtest-vendor, nav-msgs, rclcpp, rviz2, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-fuse-tutorials";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_tutorials/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "b8c458be4b97aa43482d3cb753601f5da6755396581658f0f12efba6008886bb";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_tutorials/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "d3121627da1bbbe379fadad4fa826746683de9fda791b2074b188afba9428df4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fuse-variables/default.nix
+++ b/distros/rolling/fuse-variables/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ceres-solver, fuse-core, fuse-graphs, gtest-vendor, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-fuse-variables";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_variables/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "57ac49fbfcffd10fe63e63d811c4771626d8f5d196560ee1e376b86688389afc";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_variables/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "548653ebedf7aa4276a7f0ea9edd028aaa0eb4814e8d69b4fdafa9bb1da6fd26";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fuse-viz/default.nix
+++ b/distros/rolling/fuse-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, eigen, fuse-constraints, fuse-core, fuse-msgs, fuse-variables, geometry-msgs, gtest-vendor, qt5, rviz-common, rviz-rendering, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-fuse-viz";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_viz/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "5be60abff462a16e79653d77aed8ad3059625c4759260ced48f78828983c5fa2";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse_viz/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "236870027cec7b3de40a2d1d2e36a8c42f211ecbbbd903d3c308c7022ffbdffe";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fuse/default.nix
+++ b/distros/rolling/fuse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, fuse-constraints, fuse-core, fuse-doc, fuse-graphs, fuse-models, fuse-msgs, fuse-optimizers, fuse-publishers, fuse-variables, fuse-viz, gtest-vendor }:
 buildRosPackage {
   pname = "ros-rolling-fuse";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "7561b6f668e22a2a959c6041fabe8419bea5e994498f7d623897cb5eefaa7bd9";
+    url = "https://github.com/ros2-gbp/fuse-release/archive/release/rolling/fuse/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "24463f7fac295b65f925985acdb4d182c677a683ce02e7cc745c4c0285e4107d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -194,6 +194,8 @@ self: super: {
 
  async-web-server-cpp = self.callPackage ./async-web-server-cpp {};
 
+ at-sonde-ros-driver = self.callPackage ./at-sonde-ros-driver {};
+
  automatika-embodied-agents = self.callPackage ./automatika-embodied-agents {};
 
  automatika-ros-sugar = self.callPackage ./automatika-ros-sugar {};
@@ -359,6 +361,8 @@ self: super: {
  cascade-lifecycle-msgs = self.callPackage ./cascade-lifecycle-msgs {};
 
  catch-ros2 = self.callPackage ./catch-ros2 {};
+
+ chained-filter-controller = self.callPackage ./chained-filter-controller {};
 
  chomp-motion-planner = self.callPackage ./chomp-motion-planner {};
 
@@ -1247,6 +1251,8 @@ self: super: {
  motion-capture-tracking = self.callPackage ./motion-capture-tracking {};
 
  motion-capture-tracking-interfaces = self.callPackage ./motion-capture-tracking-interfaces {};
+
+ motion-primitives-controllers = self.callPackage ./motion-primitives-controllers {};
 
  mouse-teleop = self.callPackage ./mouse-teleop {};
 
@@ -2299,8 +2305,6 @@ self: super: {
  rviz-2d-overlay-msgs = self.callPackage ./rviz-2d-overlay-msgs {};
 
  rviz-2d-overlay-plugins = self.callPackage ./rviz-2d-overlay-plugins {};
-
- rviz-assimp-vendor = self.callPackage ./rviz-assimp-vendor {};
 
  rviz-common = self.callPackage ./rviz-common {};
 

--- a/distros/rolling/geometry2/default.nix
+++ b/distros/rolling/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-rolling-geometry2";
-  version = "0.44.0-r1";
+  version = "0.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/geometry2/0.44.0-1.tar.gz";
-    name = "0.44.0-1.tar.gz";
-    sha256 = "229070f3cbf0c7f41a8c7bc58c0632cd660abc9721d6e7a0c9d4253c4c5dfabb";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/geometry2/0.45.0-1.tar.gz";
+    name = "0.45.0-1.tar.gz";
+    sha256 = "0d0bc3235174c6f260ab1906e6ba9317fab2ace8c466e3651e7a60b22b7ab449";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gpio-controllers/default.nix
+++ b/distros/rolling/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-gpio-controllers";
-  version = "5.5.0-r1";
+  version = "5.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gpio_controllers/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "324e39cd6215e7277e29038837792c031bc605a11ba4599e9031f35f8f1d3fab";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gpio_controllers/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "5793c9a6f195ea1d8616ed2c9337d66fc17678117e3d0e1590bdcdde1c5c62d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gps-sensor-broadcaster/default.nix
+++ b/distros/rolling/gps-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-gps-sensor-broadcaster";
-  version = "5.5.0-r1";
+  version = "5.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gps_sensor_broadcaster/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "024806135edf3f56c9d2b0c0e7b651e2ac7baf371f7410073bddf8d44b38bbd5";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gps_sensor_broadcaster/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "eaed8aca68ad5e5711cc9a975793c135a94cfee4efaa7a2d5cf23883ea176f89";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-physics-vendor/default.nix
+++ b/distros/rolling/gz-physics-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, bullet, cmake, eigen, gbenchmark, gz-cmake-vendor, gz-common-vendor, gz-dartsim-vendor, gz-math-vendor, gz-plugin-vendor, gz-utils-vendor, sdformat-vendor }:
 buildRosPackage {
   pname = "ros-rolling-gz-physics-vendor";
-  version = "0.2.2-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_physics_vendor-release/archive/release/rolling/gz_physics_vendor/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "c1d7dcd2db9e39ed03efbc81de6ca1b80f2e27ccc7e2ec805982d413ef8aaf3a";
+    url = "https://github.com/ros2-gbp/gz_physics_vendor-release/archive/release/rolling/gz_physics_vendor/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "9bbb02f21b7bf41aad4cc8b5df18947aaacffa9dce063b283e6e80d05219e485";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-physics8 8.2.0
+    description = "Vendor package for: gz-physics8 8.3.0
 
     Gazebo Physics : Physics classes and functions for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-rendering-vendor/default.nix
+++ b/distros/rolling/gz-rendering-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, freeglut, freeimage, glew, gz-cmake-vendor, gz-common-vendor, gz-math-vendor, gz-ogre-next-vendor, gz-plugin-vendor, gz-utils-vendor, ogre1_9, util-linux, vulkan-loader, xorg }:
 buildRosPackage {
   pname = "ros-rolling-gz-rendering-vendor";
-  version = "0.2.3-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_rendering_vendor-release/archive/release/rolling/gz_rendering_vendor/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "0d4b7545c71a9321bb3de9b3bc9c9c1832ae0ad507641a521409412d204752c1";
+    url = "https://github.com/ros2-gbp/gz_rendering_vendor-release/archive/release/rolling/gz_rendering_vendor/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "987f6b0740e23d1019cfeb08df9dee675c2f9694930b888f48e74e1bb2ebb52a";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-rendering9 9.2.0
+    description = "Vendor package for: gz-rendering9 9.3.0
 
     Gazebo Rendering: Rendering library for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-sim-vendor/default.nix
+++ b/distros/rolling/gz-sim-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, freeglut, freeimage, gbenchmark, glew, gz-cmake-vendor, gz-common-vendor, gz-fuel-tools-vendor, gz-gui-vendor, gz-math-vendor, gz-msgs-vendor, gz-physics-vendor, gz-plugin-vendor, gz-rendering-vendor, gz-sensors-vendor, gz-tools-vendor, gz-transport-vendor, gz-utils-vendor, protobuf, python3Packages, qt5, sdformat-vendor, tinyxml-2, util-linux, xorg }:
 buildRosPackage {
   pname = "ros-rolling-gz-sim-vendor";
-  version = "0.2.1-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_sim_vendor-release/archive/release/rolling/gz_sim_vendor/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "7539357780e3a268f823f70d4a874386581e96686daa7947c743d307192d832b";
+    url = "https://github.com/ros2-gbp/gz_sim_vendor-release/archive/release/rolling/gz_sim_vendor/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "f8106bc255b997f6406a8adffb9d1fc83f8bba63a11e87f15d9520f7d87f0234";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-sim9 9.1.0
+    description = "Vendor package for: gz-sim9 9.3.0
 
     Gazebo Sim : A Robotic Simulator";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-tools-vendor/default.nix
+++ b/distros/rolling/gz-tools-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, ruby }:
 buildRosPackage {
   pname = "ros-rolling-gz-tools-vendor";
-  version = "0.1.2-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_tools_vendor-release/archive/release/rolling/gz_tools_vendor/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "56f727799fd761307428214ac68ce295ae040efcddb6f702f06ee1fe9520c524";
+    url = "https://github.com/ros2-gbp/gz_tools_vendor-release/archive/release/rolling/gz_tools_vendor/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "c7400c958843631c66f94c47dc037437ecde5cda278dd531caa908f5fade4d0e";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-tools2 2.0.2
+    description = "Vendor package for: gz-tools2 2.0.3
 
     Gazebo Tools: Entrypoint to Gazebo's command line interface";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/hardware-interface-testing/default.nix
+++ b/distros/rolling/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, fmt, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface-testing";
-  version = "5.5.0-r1";
+  version = "5.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface_testing/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "25c709c0b37c2894f6a34fe948cfdcf36834e90951406563213e052cf0896dd5";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface_testing/5.6.0-1.tar.gz";
+    name = "5.6.0-1.tar.gz";
+    sha256 = "f41fe64082a64e3411c8ea585cafb24b93759e6fd6aeadfa9b250d8574c554fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/hardware-interface/default.nix
+++ b/distros/rolling/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, control-msgs, fmt, joint-limits, lifecycle-msgs, pal-statistics, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sdformat-urdf, tinyxml2-vendor, urdf }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface";
-  version = "5.5.0-r1";
+  version = "5.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "6713041612dc366d968846374a4f67077eb011445bd3529ca28eebcd5e2890e8";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/5.6.0-1.tar.gz";
+    name = "5.6.0-1.tar.gz";
+    sha256 = "8c907151e2bf0ed9de691147fa33a2899ea651a0e5584088584c3a3dbabc0384";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/imu-sensor-broadcaster/default.nix
+++ b/distros/rolling/imu-sensor-broadcaster/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, eigen, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-imu-sensor-broadcaster";
-  version = "5.5.0-r1";
+  version = "5.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "252bed8549a49ec70431c45dbd9094a21525ee59394ad8933e47ae27967c6652";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "4f60140582e3f452c6f3af2e385a289dd2494f93858a6e721cef76a092f95e2a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros2-control-cmake ];
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager hardware-interface-testing ros2-control-test-assets ];
-  propagatedBuildInputs = [ backward-ros controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools sensor-msgs ];
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager hardware-interface-testing ros2-control-test-assets tf2 tf2-geometry-msgs ];
+  propagatedBuildInputs = [ backward-ros controller-interface eigen generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/joint-limits/default.nix
+++ b/distros/rolling/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, fmt, generate-parameter-library, launch-ros, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-limits";
-  version = "5.5.0-r1";
+  version = "5.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "22e0daac379c32198cf559470b1b9607a2899256ee6d3b3b515dd9cd22ff7c4a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/5.6.0-1.tar.gz";
+    name = "5.6.0-1.tar.gz";
+    sha256 = "aa76a4d0f25309bcfaabd7020e9ecee64b8bd33d4accfe9383577801f23e1a24";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-state-broadcaster/default.nix
+++ b/distros/rolling/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-state-broadcaster";
-  version = "5.5.0-r1";
+  version = "5.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "4d9bd8f83aa5ec80ec49ce720e7d15e78b418b480b086164086e50661012e0d8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "04b1805b4d7feb8883164b8cb671790bf49a657895a90f106fb39464728f60dd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-trajectory-controller/default.nix
+++ b/distros/rolling/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-trajectory-controller";
-  version = "5.5.0-r1";
+  version = "5.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "4e9caa84ba868bd09ae4296e15ae139290dfb0c68a6d71d32669466a72ac10a3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "2e7d4d711a092f3c37bc8694fc98e3c27fd1198a67adaf574356abf8be42c640";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/kinematics-interface-kdl/default.nix
+++ b/distros/rolling/kinematics-interface-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, eigen, eigen3-cmake-module, kdl-parser, kinematics-interface, pluginlib, ros2-control-cmake, ros2-control-test-assets, tf2-eigen-kdl }:
 buildRosPackage {
   pname = "ros-rolling-kinematics-interface-kdl";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/rolling/kinematics_interface_kdl/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "835bd6680801884dcc281f1017bc22e8a75fcc0c6c546e6de9f38326cc9504c8";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/rolling/kinematics_interface_kdl/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "c318debe323c095e640954e8c275e0b8f5de05cfd3446118959958ae82e5b64f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/kinematics-interface/default.nix
+++ b/distros/rolling/kinematics-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, rclcpp-lifecycle, ros2-control-cmake }:
 buildRosPackage {
   pname = "ros-rolling-kinematics-interface";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/rolling/kinematics_interface/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "fc0e7b1685e1e6d4c8eb4493a555f300b9feceac982e353cbae48ae4e8b5464f";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/rolling/kinematics_interface/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "103f10238cf106c0f5e38ec0c80f655c35e1d601b7a72a54e9396dddac7bf9db";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/kompass-interfaces/default.nix
+++ b/distros/rolling/kompass-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-kompass-interfaces";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kompass-release/archive/release/rolling/kompass_interfaces/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "adf6bf1bc2811b59d2562bc8b948b67411bad7415c6dc902b9ccd2b3878e1c91";
+    url = "https://github.com/ros2-gbp/kompass-release/archive/release/rolling/kompass_interfaces/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "ac79e7fbf7d0a21d6b3487f62c000f9b41800e71171a953d2e7fdfeb898fd363";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/kompass/default.nix
+++ b/distros/rolling/kompass/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, automatika-ros-sugar, kompass-interfaces, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-kompass";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kompass-release/archive/release/rolling/kompass/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "280ea9e319fe6d88cb87b6bf5ea6a3f318a75ca90b1d1f838b3bd41ddfce6a43";
+    url = "https://github.com/ros2-gbp/kompass-release/archive/release/rolling/kompass/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "7793fa1ceb7cd5d6510ec46619f94c9bcf3c236ff39742076fe88f9383cdfc39";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/libcaer-driver/default.nix
+++ b/distros/rolling/libcaer-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-xmllint, camera-info-manager, event-camera-msgs, image-transport, libcaer-vendor, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-libcaer-driver";
-  version = "1.5.2-r1";
+  version = "1.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libcaer_driver-release/archive/release/rolling/libcaer_driver/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "ae7a3af7674617aa8326b6ad9b3876fcbacf4bdb203cfd642c9765e4f6ca188a";
+    url = "https://github.com/ros2-gbp/libcaer_driver-release/archive/release/rolling/libcaer_driver/1.5.3-1.tar.gz";
+    name = "1.5.3-1.tar.gz";
+    sha256 = "6ca2a99710e545773d9fd687b78b7585f2f281a1e9bd95cd0bbe3cb1e96fd165";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mapviz-interfaces/default.nix
+++ b/distros/rolling/mapviz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-mapviz-interfaces";
-  version = "2.5.8-r1";
+  version = "2.5.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/mapviz_interfaces/2.5.8-1.tar.gz";
-    name = "2.5.8-1.tar.gz";
-    sha256 = "7261cb666e916d691df861a0ffa474e6032b4b87a167e793fdc9631860e45229";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/mapviz_interfaces/2.5.10-1.tar.gz";
+    name = "2.5.10-1.tar.gz";
+    sha256 = "f6a5d49a321e930cf7b38aecdfa2d1dd519f635f860200e6f9fd1457d32486c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mapviz-plugins/default.nix
+++ b/distros/rolling/mapviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, cv-bridge, geometry-msgs, gps-msgs, image-transport, map-msgs, mapviz, marti-common-msgs, marti-nav-msgs, marti-sensor-msgs, marti-visualization-msgs, nav-msgs, opencv, pluginlib, qt5, rclcpp, rclcpp-action, ros-environment, sensor-msgs, std-msgs, std-srvs, stereo-msgs, swri-image-util, swri-math-util, swri-route-util, swri-transform-util, tf2, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mapviz-plugins";
-  version = "2.5.8-r1";
+  version = "2.5.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/mapviz_plugins/2.5.8-1.tar.gz";
-    name = "2.5.8-1.tar.gz";
-    sha256 = "9bc6ed3715dda451510d8e4e15de55aaa91e41e09cac98fa3c53e880191929d5";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/mapviz_plugins/2.5.10-1.tar.gz";
+    name = "2.5.10-1.tar.gz";
+    sha256 = "737745f5322369df77b0e7d5355f0aba14ccd32f61a892d25e9a158ce663f014";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mapviz/default.nix
+++ b/distros/rolling/mapviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, freeglut, geometry-msgs, glew, image-transport, mapviz-interfaces, opencv, pkg-config, pluginlib, qt5, rclcpp, ros-environment, rqt-gui, rqt-gui-cpp, std-srvs, swri-math-util, swri-transform-util, tf2, tf2-geometry-msgs, tf2-ros, xorg, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-mapviz";
-  version = "2.5.8-r1";
+  version = "2.5.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/mapviz/2.5.8-1.tar.gz";
-    name = "2.5.8-1.tar.gz";
-    sha256 = "6e73f3e6fa8f7c7f303ee268b978e5786884ad2be1ae2bfd842f5846d2d2e5f2";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/mapviz/2.5.10-1.tar.gz";
+    name = "2.5.10-1.tar.gz";
+    sha256 = "472e86646af6ab64e4232eadd140efb5112aca8c021f82c271cc40bfff03d64c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mecanum-drive-controller/default.nix
+++ b/distros/rolling/mecanum-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mecanum-drive-controller";
-  version = "5.5.0-r1";
+  version = "5.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/mecanum_drive_controller/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "d30438f5504e2bb7b175a29a1173b008c24472e7dfe2391dea5fdabeea5ae204";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/mecanum_drive_controller/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "ca75c306c39e71c0ac73fc5934cb028957c9036c26e7b4ccef880f69ca821b5e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-common/default.nix
+++ b/distros/rolling/mola-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-common";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/rolling/mola_common/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "f33aba3ed6759f2622031c508afa3d1d6edf1c26ecc27bcc8aaf51df4a151bf0";
+    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/rolling/mola_common/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "625fb59dd6bef533806677577f4e8cb0d8f51ec759b9aca4fc434dbc6ed87a5d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-lidar-odometry/default.nix
+++ b/distros/rolling/mola-lidar-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-rolling-mola-lidar-odometry";
-  version = "0.8.0-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/rolling/mola_lidar_odometry/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "59d25086a374c21ce49b7bbace49b45bd080f2d458cb6c028f383b1a6a7bbd84";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/rolling/mola_lidar_odometry/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "825476ddb8f60d206e17ac0fbf23fcc1d63f9168fee57b073b4216c958b90c4d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/motion-primitives-controllers/default.nix
+++ b/distros/rolling/motion-primitives-controllers/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs }:
+buildRosPackage {
+  pname = "ros-rolling-motion-primitives-controllers";
+  version = "5.6.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/motion_primitives_controllers/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "4a2bb15ba2f38e3c41757ddfd9ff54dffd90ad1a3556615522d9aeacfb249bf7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake generate-parameter-library ros2-control-cmake ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface ros2-control-test-assets ];
+  propagatedBuildInputs = [ control-msgs controller-interface hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools std-srvs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Package to control robots using motion primitives like PTP, LIN and CIRC";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/mp2p-icp/default.nix
+++ b/distros/rolling/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, ros-environment, tbb_2021_11 }:
 buildRosPackage {
   pname = "ros-rolling-mp2p-icp";
-  version = "1.7.1-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp/1.7.1-1.tar.gz";
-    name = "1.7.1-1.tar.gz";
-    sha256 = "5f4c3152f95a6f61a2fb4eec09469bbc8e5a78ba1ab3881fba123306c5009dc3";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "3aa5030207efc138c4daa751580313f92a67a322e558bed715a08514c51e4c8c";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-apps/default.nix
+++ b/distros/rolling/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, openni2, pkg-config, python3Packages, ros-environment, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-apps";
-  version = "2.14.11-r1";
+  version = "2.14.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_apps/2.14.11-1.tar.gz";
-    name = "2.14.11-1.tar.gz";
-    sha256 = "accfb4e74f8c03eb03d6c0e2ff787d714b2332703521abb4aaacdb56bc44055c";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_apps/2.14.12-1.tar.gz";
+    name = "2.14.12-1.tar.gz";
+    sha256 = "229003a2ff97ca8da6eb03356001ebe89bcf024802a629dad2a97866c529b5de";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libapps/default.nix
+++ b/distros/rolling/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libapps";
-  version = "2.14.11-r1";
+  version = "2.14.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libapps/2.14.11-1.tar.gz";
-    name = "2.14.11-1.tar.gz";
-    sha256 = "22bc6ecf6d48a33675790ac0338153f6b1dc34ceb4accf6b502691b0093f837f";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libapps/2.14.12-1.tar.gz";
+    name = "2.14.12-1.tar.gz";
+    sha256 = "cbe2215f86804a7b610de5566b3647a10d993312e1c5323b66c037f89fc175a9";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libbase/default.nix
+++ b/distros/rolling/mrpt-libbase/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tbb_2021_11, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libbase";
-  version = "2.14.11-r1";
+  version = "2.14.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libbase/2.14.11-1.tar.gz";
-    name = "2.14.11-1.tar.gz";
-    sha256 = "8bb1117faab5bb2b2d955ae61f60e25595428fb6fce0f3e69dd84f045a507aec";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libbase/2.14.12-1.tar.gz";
+    name = "2.14.12-1.tar.gz";
+    sha256 = "9d9506b7e92509ec494476841617e5f5d3cd46fb2bdd73e58cf0100deec4a8d6";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libgui/default.nix
+++ b/distros/rolling/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libgui";
-  version = "2.14.11-r1";
+  version = "2.14.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libgui/2.14.11-1.tar.gz";
-    name = "2.14.11-1.tar.gz";
-    sha256 = "075d2b86197e944f538f89db0d4af136784aa79ca1ed3f52199fed5c6c713ae7";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libgui/2.14.12-1.tar.gz";
+    name = "2.14.12-1.tar.gz";
+    sha256 = "89e9cf7b4f428695f49643774d324022b0630dde3039ff1cc5630adf856845c3";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libhwdrivers/default.nix
+++ b/distros/rolling/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libhwdrivers";
-  version = "2.14.11-r1";
+  version = "2.14.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libhwdrivers/2.14.11-1.tar.gz";
-    name = "2.14.11-1.tar.gz";
-    sha256 = "c9d652c7581e1ce98b73b55d7150ba3a0438edfce2b9e5a0bea98230a9ae1a33";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libhwdrivers/2.14.12-1.tar.gz";
+    name = "2.14.12-1.tar.gz";
+    sha256 = "227295284e6715311c04ce01204e072abf98185310ec0cbbe17b2f2542174311";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libmaps/default.nix
+++ b/distros/rolling/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libmaps";
-  version = "2.14.11-r1";
+  version = "2.14.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmaps/2.14.11-1.tar.gz";
-    name = "2.14.11-1.tar.gz";
-    sha256 = "106d54178ad1823128f561c2166f01f8f031c599edd449b05df7d9e9fec03424";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmaps/2.14.12-1.tar.gz";
+    name = "2.14.12-1.tar.gz";
+    sha256 = "9e118c7ed6eb6f1a4eb883f08f04ce49fe8fda24d63a2ac91505b86773c174c5";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libmath/default.nix
+++ b/distros/rolling/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libmath";
-  version = "2.14.11-r1";
+  version = "2.14.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmath/2.14.11-1.tar.gz";
-    name = "2.14.11-1.tar.gz";
-    sha256 = "95bf75529ca896e0b362e6a8102aa6ae96b52c0b0b03c5c55f409b3f635df664";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmath/2.14.12-1.tar.gz";
+    name = "2.14.12-1.tar.gz";
+    sha256 = "bfe5a75f604134b9a2ebbcc6bdbd690d6de2258394882c85f1f7a470c73fb49c";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libnav/default.nix
+++ b/distros/rolling/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libnav";
-  version = "2.14.11-r1";
+  version = "2.14.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libnav/2.14.11-1.tar.gz";
-    name = "2.14.11-1.tar.gz";
-    sha256 = "b9cefbccf413870c192a5b4d63f73e9ef5e2dd059891092034f8b6da2b37e756";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libnav/2.14.12-1.tar.gz";
+    name = "2.14.12-1.tar.gz";
+    sha256 = "88e6f265aa41da3f3b9eb803d5092929438e0aeec24a92bd7ca33b0a68fabfaa";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libobs/default.nix
+++ b/distros/rolling/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libobs";
-  version = "2.14.11-r1";
+  version = "2.14.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libobs/2.14.11-1.tar.gz";
-    name = "2.14.11-1.tar.gz";
-    sha256 = "7c0ce222b7c1c799bc8dbb2a85fa726034b0c3169ded2c03c0801878fbb0add8";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libobs/2.14.12-1.tar.gz";
+    name = "2.14.12-1.tar.gz";
+    sha256 = "220be77885aa9d84538e23d1ffc9bb907c50bde94abf9c7b60c8741708a9bbc6";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libopengl/default.nix
+++ b/distros/rolling/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libopengl";
-  version = "2.14.11-r1";
+  version = "2.14.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libopengl/2.14.11-1.tar.gz";
-    name = "2.14.11-1.tar.gz";
-    sha256 = "13e87d3ec035d377194795dff382a1dc37ddc4b6e46900cd87f1cb43e70e35d0";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libopengl/2.14.12-1.tar.gz";
+    name = "2.14.12-1.tar.gz";
+    sha256 = "3906aec74f3e92b0766f988198a38375e8fd1d8e9596be6513b586170ba7882e";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libposes/default.nix
+++ b/distros/rolling/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libposes";
-  version = "2.14.11-r1";
+  version = "2.14.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libposes/2.14.11-1.tar.gz";
-    name = "2.14.11-1.tar.gz";
-    sha256 = "440d87c3c4963b050e9065e821a4fbbb619a3fcead8acea92054d4e0db5fd9a9";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libposes/2.14.12-1.tar.gz";
+    name = "2.14.12-1.tar.gz";
+    sha256 = "f7540854918f7cf520c15fae76d87ea8009e7580f0d86d8f64500c7e979a9f87";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libros-bridge/default.nix
+++ b/distros/rolling/mrpt-libros-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, tf2, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libros-bridge";
-  version = "2.14.11-r1";
+  version = "2.14.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libros_bridge/2.14.11-1.tar.gz";
-    name = "2.14.11-1.tar.gz";
-    sha256 = "cbfce56cb4106b85b1c8005c07b3f4dd4c2a50ac3f96e64c7e5756f05b590fee";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libros_bridge/2.14.12-1.tar.gz";
+    name = "2.14.12-1.tar.gz";
+    sha256 = "70d817e4b1e676176cee43e9e7cab9100ce5f1ea592f6b0d20412469a68e07b9";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libslam/default.nix
+++ b/distros/rolling/mrpt-libslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, tbb_2021_11, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libslam";
-  version = "2.14.11-r1";
+  version = "2.14.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libslam/2.14.11-1.tar.gz";
-    name = "2.14.11-1.tar.gz";
-    sha256 = "82e8b52d949e5095ee3d0a8ce293c1204b798ebbed06fa2cc73a3c7e0b2c7920";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libslam/2.14.12-1.tar.gz";
+    name = "2.14.12-1.tar.gz";
+    sha256 = "7e778cd166c7500fac465f19c0ebcf1586bd2cbe7bf6b22204aaa98b0663b333";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libtclap/default.nix
+++ b/distros/rolling/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libtclap";
-  version = "2.14.11-r1";
+  version = "2.14.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libtclap/2.14.11-1.tar.gz";
-    name = "2.14.11-1.tar.gz";
-    sha256 = "b9e346d78cd8350f42ca9eba4442131cdd271e4d392d8fb9d11083f84c577c65";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libtclap/2.14.12-1.tar.gz";
+    name = "2.14.12-1.tar.gz";
+    sha256 = "13b3efd51a7aaef6312e19fe9e101475b9c1252a6c3b044ce8dc9ff0191d13f3";
   };
 
   buildType = "cmake";

--- a/distros/rolling/multires-image/default.nix
+++ b/distros/rolling/multires-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, mapviz, pluginlib, qt5, rclcpp, rclpy, swri-math-util, swri-transform-util, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-multires-image";
-  version = "2.5.8-r1";
+  version = "2.5.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/multires_image/2.5.8-1.tar.gz";
-    name = "2.5.8-1.tar.gz";
-    sha256 = "b0c4a0685172158a99f704f666f7d28ca54f3787d3f8948d55dd648551d873b6";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/multires_image/2.5.10-1.tar.gz";
+    name = "2.5.10-1.tar.gz";
+    sha256 = "c029a62a4b46df1d6c4dc546789e1e841bd34e444265b3a12b20668b278a8734";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/omni-wheel-drive-controller/default.nix
+++ b/distros/rolling/omni-wheel-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, eigen, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-omni-wheel-drive-controller";
-  version = "5.5.0-r1";
+  version = "5.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/omni_wheel_drive_controller/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "e6346629fc9f61a2dcda593b76fda6cff90d8ed482011a10c6247b1807634dd5";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/omni_wheel_drive_controller/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "117403ab178848a583afbbe0095d7fedfeefcbd345890de4249f78da85208c9e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/parallel-gripper-controller/default.nix
+++ b/distros/rolling/parallel-gripper-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-parallel-gripper-controller";
-  version = "5.5.0-r1";
+  version = "5.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/parallel_gripper_controller/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "37e98f47df32fad92edf3b699d39f4acd3d5f3a1a1a518957e6bb1f1751a3c0c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/parallel_gripper_controller/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "dee9e836cd8ad97978cd0fffdb9cf359925a9e45c5f2ac28f5adae838e510560";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pid-controller/default.nix
+++ b/distros/rolling/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-pid-controller";
-  version = "5.5.0-r1";
+  version = "5.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pid_controller/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "b4ef9b8f6a5a13aee42cb83e2df7ec5641082ab016a0c0a8e0b052e8bbfe3550";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pid_controller/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "ba4278cb1a43f2514b457de6d1af060dd652d7d0b7a743259e90e924602b8b40";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pose-broadcaster/default.nix
+++ b/distros/rolling/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-pose-broadcaster";
-  version = "5.5.0-r1";
+  version = "5.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pose_broadcaster/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "3a97c6ca432dea0bee683a725ab56bfa0ec3873b2ffac817c145f435cc23765b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pose_broadcaster/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "17da4dcdac2ff336c44881ede7cc22a555f8ed8cf9236bb5068a76a6aa13bf2a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/position-controllers/default.nix
+++ b/distros/rolling/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-position-controllers";
-  version = "5.5.0-r1";
+  version = "5.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "6a906970d22d58d53e1ef76337e4d0f7a318fb1792c52fddfeac7a192e44760d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "bf9f7feac88dbd8930d1834c01d4b77c3af5236a7a39107e8fad818b3b42ce5b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/range-sensor-broadcaster/default.nix
+++ b/distros/rolling/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-range-sensor-broadcaster";
-  version = "5.5.0-r1";
+  version = "5.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "d8c62cb9d01e477f089a6756836849762dfff2b5121fcb878e2615ed85eda5e3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "710be05bdfbf86d0981201580ac766bead22d37d19bb7313ddfb5e5b798dc6a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/robot-localization/default.nix
+++ b/distros/rolling/robot-localization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, boost, builtin-interfaces, diagnostic-msgs, diagnostic-updater, eigen, geographic-msgs, geographiclib, geometry-msgs, launch-ros, launch-testing-ament-cmake, message-filters, nav-msgs, rclcpp, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-robot-localization";
-  version = "3.9.3-r1";
+  version = "3.10.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_localization-release/archive/release/rolling/robot_localization/3.9.3-1.tar.gz";
-    name = "3.9.3-1.tar.gz";
-    sha256 = "333762bbe04006f88cc5f094fc5bc031b12f378483360d5cb9876b0ee9340259";
+    url = "https://github.com/ros2-gbp/robot_localization-release/archive/release/rolling/robot_localization/3.10.0-2.tar.gz";
+    name = "3.10.0-2.tar.gz";
+    sha256 = "bd244f06fa1b6e558a75d93e1aa2b40961f6f4fd0df5b76c716ed89c201eebaa";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/robotraconteur/default.nix
+++ b/distros/rolling/robotraconteur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bluez, boost, cmake, dbus, gtest, libusb1, openssl, python3, python3Packages, zlib }:
 buildRosPackage {
   pname = "ros-rolling-robotraconteur";
-  version = "1.2.5-r1";
+  version = "1.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robotraconteur-release/archive/release/rolling/robotraconteur/1.2.5-1.tar.gz";
-    name = "1.2.5-1.tar.gz";
-    sha256 = "f4fdcbb50cb36883ee6c3a81a44886c39fbe2ef2512887f2d0270e715378f54a";
+    url = "https://github.com/ros2-gbp/robotraconteur-release/archive/release/rolling/robotraconteur/1.2.6-1.tar.gz";
+    name = "1.2.6-1.tar.gz";
+    sha256 = "c36918fdc383f633f2f7147d425a5a398e9ea808cfe5500a0811e06c39a34f09";
   };
 
   buildType = "cmake";

--- a/distros/rolling/ros2-control-test-assets/default.nix
+++ b/distros/rolling/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control-test-assets";
-  version = "5.5.0-r1";
+  version = "5.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "541a744cbfad6c3ec14c0e2b64ec1a4d8528150a1b4c54cbe5f2086837758352";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/5.6.0-1.tar.gz";
+    name = "5.6.0-1.tar.gz";
+    sha256 = "9da5f917de0b9194b3487dbd929541e3eba0d624befbccc2005e0d099ece5405";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control/default.nix
+++ b/distros/rolling/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control";
-  version = "5.5.0-r1";
+  version = "5.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "e743e1122afc945c0336707b291ce390643dc14b24545ba24bcab352b523f30d";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/5.6.0-1.tar.gz";
+    name = "5.6.0-1.tar.gz";
+    sha256 = "5a622d3acb111d03f7c053667b147a51f96d86231846fda396b7239cd19c3f1f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-controllers-test-nodes/default.nix
+++ b/distros/rolling/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers-test-nodes";
-  version = "5.5.0-r1";
+  version = "5.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "7656793e1ecdf2c4f1157798f2a721803c41b918cdc3feecf7ad5eac720240a8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "11995d34ec220566ac670d59516f4b06cdd906977ad8dbf4ef13434a22b2b68f";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2-controllers/default.nix
+++ b/distros/rolling/ros2-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gps-sensor-broadcaster, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, omni-wheel-drive-controller, parallel-gripper-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
+{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, chained-filter-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gps-sensor-broadcaster, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, motion-primitives-controllers, omni-wheel-drive-controller, parallel-gripper-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers";
-  version = "5.5.0-r1";
+  version = "5.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "c44629974138259618d5b0e7ea8e75374055cd4b02ac22cecf958297a5f17d7c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "9ec5298980be616f2bfbfc7597f753724fa2d3a2c3fafa113dc15283ee844e4d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ackermann-steering-controller admittance-controller bicycle-steering-controller diff-drive-controller effort-controllers force-torque-sensor-broadcaster forward-command-controller gpio-controllers gps-sensor-broadcaster imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller mecanum-drive-controller omni-wheel-drive-controller parallel-gripper-controller pid-controller pose-broadcaster position-controllers range-sensor-broadcaster steering-controllers-library tricycle-controller tricycle-steering-controller velocity-controllers ];
+  propagatedBuildInputs = [ ackermann-steering-controller admittance-controller bicycle-steering-controller chained-filter-controller diff-drive-controller effort-controllers force-torque-sensor-broadcaster forward-command-controller gpio-controllers gps-sensor-broadcaster imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller mecanum-drive-controller motion-primitives-controllers omni-wheel-drive-controller parallel-gripper-controller pid-controller pose-broadcaster position-controllers range-sensor-broadcaster steering-controllers-library tricycle-controller tricycle-steering-controller velocity-controllers ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/ros2controlcli/default.nix
+++ b/distros/rolling/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-rolling-ros2controlcli";
-  version = "5.5.0-r1";
+  version = "5.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "67533e5d695a66ea76f39bd312a7f63d6c8ea2682251ffd4395d2965ed431fdc";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/5.6.0-1.tar.gz";
+    name = "5.6.0-1.tar.gz";
+    sha256 = "bc9ffb19a048f52b3b78378531ceb9b0266f4de9781a0c02feb01f5b7ad32bea";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-controller-manager/default.nix
+++ b/distros/rolling/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-controller-manager";
-  version = "5.5.0-r1";
+  version = "5.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "841a4c45a6d9c8b0b337e7f44648c5910d8b628f71cfa84f00fe320c7db4cccb";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/5.6.0-1.tar.gz";
+    name = "5.6.0-1.tar.gz";
+    sha256 = "dde3072074c9eb65f678d7464aa0e0271fb9fbfca2e9f3aa3a0d4e1ee738095b";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-joint-trajectory-controller/default.nix
+++ b/distros/rolling/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-joint-trajectory-controller";
-  version = "5.5.0-r1";
+  version = "5.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "a514a53770b411413645438d4985841f850271bc7b331538d42b193621320d4c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "3e1fc253e3dbc8c1af5af651d0af84bfdaa5865e2b2c264433db05a9f6c942f1";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-robot-steering/default.nix
+++ b/distros/rolling/rqt-robot-steering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, geometry-msgs, python-qt-binding, python3Packages, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-robot-steering";
-  version = "4.0.0-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_robot_steering-release/archive/release/rolling/rqt_robot_steering/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "29f27c4e43d0440626157a95fad48d50ba69a3177cb10a289b76bd7477d5f9a9";
+    url = "https://github.com/ros2-gbp/rqt_robot_steering-release/archive/release/rolling/rqt_robot_steering/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "7a62c49ec9ce205d844491431127e43679163922f693de8c9461850fbbec1938";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rviz-common/default.nix
+++ b/distros/rolling/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-common";
-  version = "15.1.8-r1";
+  version = "15.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/15.1.8-1.tar.gz";
-    name = "15.1.8-1.tar.gz";
-    sha256 = "612fea69b9e79db2580bc62f99dd7511a06a435c9911ad7bd1d996c63791fd43";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/15.1.9-1.tar.gz";
+    name = "15.1.9-1.tar.gz";
+    sha256 = "04c5cba93451d01f5e9336ebf2c71181a4f1c71bbdc29f19860d2718aafc29aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-default-plugins/default.nix
+++ b/distros/rolling/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, gz-math-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-resource-interfaces, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz-default-plugins";
-  version = "15.1.8-r1";
+  version = "15.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/15.1.8-1.tar.gz";
-    name = "15.1.8-1.tar.gz";
-    sha256 = "48f10019700a209a6483f90e55f351cbbc0dc34d02404bd93dd44069e08a25c3";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/15.1.9-1.tar.gz";
+    name = "15.1.9-1.tar.gz";
+    sha256 = "47eade4f1b7ec7761b8f57e3da9f5a862c150f1adc4d9f6b2d13171f1f45dd78";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-ogre-vendor/default.nix
+++ b/distros/rolling/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, glew, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-rolling-rviz-ogre-vendor";
-  version = "15.1.8-r1";
+  version = "15.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/15.1.8-1.tar.gz";
-    name = "15.1.8-1.tar.gz";
-    sha256 = "4f3df6994c006444454797e6e757230371b3898115e83f5f4e9b51c9a6ec8a6b";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/15.1.9-1.tar.gz";
+    name = "15.1.9-1.tar.gz";
+    sha256 = "7f4076255a5cd21650e5accaddbdcbf079309dffe8f85a70b821ca9fb35381a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering-tests/default.nix
+++ b/distros/rolling/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering-tests";
-  version = "15.1.8-r1";
+  version = "15.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/15.1.8-1.tar.gz";
-    name = "15.1.8-1.tar.gz";
-    sha256 = "8cdbeb3007647ec189052470fac2c92d712915b3d4362b575dc5de2623f98704";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/15.1.9-1.tar.gz";
+    name = "15.1.9-1.tar.gz";
+    sha256 = "44365463271b6711bb85031aa171c4cc71a2c496c436a4ccb5f7988b101df881";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering/default.nix
+++ b/distros/rolling/rviz-rendering/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, assimp, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering";
-  version = "15.1.8-r1";
+  version = "15.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/15.1.8-1.tar.gz";
-    name = "15.1.8-1.tar.gz";
-    sha256 = "53ae79e410b57eaed7f1af4e076a334481a268da33b079ae4321ac78f0d13a2a";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/15.1.9-1.tar.gz";
+    name = "15.1.9-1.tar.gz";
+    sha256 = "79638fc233adbb0feb019ae4c5ddab64c4b3da27890e5cee185ee5f67448e9df";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
-  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common rviz-assimp-vendor ];
-  propagatedBuildInputs = [ ament-index-cpp eigen eigen3-cmake-module qt5.qtbase resource-retriever rviz-assimp-vendor rviz-ogre-vendor ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common assimp ];
+  propagatedBuildInputs = [ ament-index-cpp assimp eigen eigen3-cmake-module qt5.qtbase resource-retriever rviz-ogre-vendor ];
   nativeBuildInputs = [ ament-cmake-ros eigen3-cmake-module ];
 
   meta = {

--- a/distros/rolling/rviz-resource-interfaces/default.nix
+++ b/distros/rolling/rviz-resource-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rviz-resource-interfaces";
-  version = "15.1.8-r1";
+  version = "15.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_resource_interfaces/15.1.8-1.tar.gz";
-    name = "15.1.8-1.tar.gz";
-    sha256 = "db74fc7eb3695cd6a5cfb304c0dae31cd25d718564caa69a0ced902a3e92c915";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_resource_interfaces/15.1.9-1.tar.gz";
+    name = "15.1.9-1.tar.gz";
+    sha256 = "de9c65a8386e0d59e2539b4d221a8c4185c18b8a1e4a27b34fc46e8dbc46cf8a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-visual-testing-framework/default.nix
+++ b/distros/rolling/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rviz-visual-testing-framework";
-  version = "15.1.8-r1";
+  version = "15.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/15.1.8-1.tar.gz";
-    name = "15.1.8-1.tar.gz";
-    sha256 = "43cf891550b4b4ac23c00e6b7dc3ca5ab57eea816de6cc918b08a2cc1ae2deb1";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/15.1.9-1.tar.gz";
+    name = "15.1.9-1.tar.gz";
+    sha256 = "895bda51ed4c61f573006abc4d35663e4595e7d871323871528d3681952238ce";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz2/default.nix
+++ b/distros/rolling/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz2";
-  version = "15.1.8-r1";
+  version = "15.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/15.1.8-1.tar.gz";
-    name = "15.1.8-1.tar.gz";
-    sha256 = "3f80d493a2d3d7a952355684f17cfd76612ae9b81c2a6bfc84428e5f788dbc9e";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/15.1.9-1.tar.gz";
+    name = "15.1.9-1.tar.gz";
+    sha256 = "c336c69e8bd1963b357a71e75f54db916d5ce072a78d8fd19ff5d94b8c354db2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/septentrio-gnss-driver/default.nix
+++ b/distros/rolling/septentrio-gnss-driver/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-ros, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, gtest-vendor, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, gtest-vendor, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-septentrio-gnss-driver";
-  version = "1.4.4-r1";
+  version = "1.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/rolling/septentrio_gnss_driver/1.4.4-1.tar.gz";
-    name = "1.4.4-1.tar.gz";
-    sha256 = "df5d7c2e9db5fec2cf9d86086479e1439b48181aebd6ceff3663906b9452619a";
+    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/rolling/septentrio_gnss_driver/1.4.5-1.tar.gz";
+    name = "1.4.5-1.tar.gz";
+    sha256 = "6af79083ee85f42841ca3c7187f3b8fa04187da2ba5fd3da0eed5245bb9583b1";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-auto rosidl-default-generators ];
+  buildInputs = [ ament-cmake rosidl-default-generators ];
   propagatedBuildInputs = [ ament-cmake-ros boost diagnostic-msgs geographiclib geometry-msgs gps-msgs gtest-vendor libpcap nav-msgs nmea-msgs rclcpp rclcpp-components rosidl-default-runtime sensor-msgs tf2 tf2-eigen tf2-geometry-msgs tf2-ros ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-auto ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = "ROSaic: C++ driver for Septentrio's GNSS and INS receivers";

--- a/distros/rolling/steering-controllers-library/default.nix
+++ b/distros/rolling/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-steering-controllers-library";
-  version = "5.5.0-r1";
+  version = "5.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "faa46c0effd0581358368ccfab5f10428970ed434949f23b3cd82d561bb95b0f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "8f355c6a4435309e7143215369afb34910b24cef760a464fcd9b11277d37d556";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-2d/default.nix
+++ b/distros/rolling/tf2-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, eigen, rclcpp, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-tf2-2d";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tf2_2d-release/archive/release/rolling/tf2_2d/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "7a92630c93d2b8217a316b87d35d72db87595eb6b78548ead77493785b6e9aca";
+    url = "https://github.com/ros2-gbp/tf2_2d-release/archive/release/rolling/tf2_2d/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "4fb3761b495700cf1fb086d47ab5019e1cc65d72eed1fcfdeaa1830152c7e536";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-bullet/default.nix
+++ b/distros/rolling/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-tf2-bullet";
-  version = "0.44.0-r1";
+  version = "0.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_bullet/0.44.0-1.tar.gz";
-    name = "0.44.0-1.tar.gz";
-    sha256 = "f9bf42119fbfbf86d4be6fe1fb7ef2fc6337e120676b41531cfed257a2e1fc34";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_bullet/0.45.0-1.tar.gz";
+    name = "0.45.0-1.tar.gz";
+    sha256 = "2502b49feab64072f3c244dd1dd5cf6114d5a35556050d39475888f19dbb7c97";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-eigen-kdl/default.nix
+++ b/distros/rolling/tf2-eigen-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, orocos-kdl-vendor, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-tf2-eigen-kdl";
-  version = "0.44.0-r1";
+  version = "0.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen_kdl/0.44.0-1.tar.gz";
-    name = "0.44.0-1.tar.gz";
-    sha256 = "d80bda15ccd5399f39266b9706f155a5ee45eec23bc43829c42e08cf63a59cb9";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen_kdl/0.45.0-1.tar.gz";
+    name = "0.45.0-1.tar.gz";
+    sha256 = "6a9412f38613b89da4ff8f2f06dda949e58004fe91e13eb88725779fee2144b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-eigen/default.nix
+++ b/distros/rolling/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-tf2-eigen";
-  version = "0.44.0-r1";
+  version = "0.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen/0.44.0-1.tar.gz";
-    name = "0.44.0-1.tar.gz";
-    sha256 = "3a51eb60e0c471ab95c4769c419277da0b7ff859a78615b34a46ee9f15f9c69e";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen/0.45.0-1.tar.gz";
+    name = "0.45.0-1.tar.gz";
+    sha256 = "c1436591345e03666b8a8b08a6f2e972081b8a3a5fe09f29927279c01542250b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-geometry-msgs/default.nix
+++ b/distros/rolling/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, orocos-kdl-vendor, python3Packages, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-geometry-msgs";
-  version = "0.44.0-r1";
+  version = "0.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_geometry_msgs/0.44.0-1.tar.gz";
-    name = "0.44.0-1.tar.gz";
-    sha256 = "500886cc437e49d855826b30ebedd3fa1bf31cbe75428847e52c6cfd82a3e307";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_geometry_msgs/0.45.0-1.tar.gz";
+    name = "0.45.0-1.tar.gz";
+    sha256 = "bd85024c2cad1383f4d9e9fd0f8f9dc19b793b061b7daac565cdd5d80a8c4b72";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-kdl/default.nix
+++ b/distros/rolling/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl-vendor, python-orocos-kdl-vendor, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-kdl";
-  version = "0.44.0-r1";
+  version = "0.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_kdl/0.44.0-1.tar.gz";
-    name = "0.44.0-1.tar.gz";
-    sha256 = "0bcc00fed261f0c6bb6f48b227d1407f3d47849bd5e881a57275f2561c94d35b";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_kdl/0.45.0-1.tar.gz";
+    name = "0.45.0-1.tar.gz";
+    sha256 = "6b4a561ca37a64c5593aeab5e998fdabe414fe391612230390581451c4f3b699";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-msgs/default.nix
+++ b/distros/rolling/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-tf2-msgs";
-  version = "0.44.0-r1";
+  version = "0.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_msgs/0.44.0-1.tar.gz";
-    name = "0.44.0-1.tar.gz";
-    sha256 = "7f26ab8c224d63cd214f70fdc5f73a4de21b91a729903cda2fbcf735bfce010f";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_msgs/0.45.0-1.tar.gz";
+    name = "0.45.0-1.tar.gz";
+    sha256 = "60dc721574ba3e84c1f8c446810067e785158eac551d89125970395643f0ac69";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-py/default.nix
+++ b/distros/rolling/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python3, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-tf2-py";
-  version = "0.44.0-r1";
+  version = "0.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_py/0.44.0-1.tar.gz";
-    name = "0.44.0-1.tar.gz";
-    sha256 = "1eb16d871b75aba9f6c178f75e2201eb85fa50f9dcee563acb2b15806dc335d1";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_py/0.45.0-1.tar.gz";
+    name = "0.45.0-1.tar.gz";
+    sha256 = "701b4eacd4ad2b4f7ddb00a1f00831699ae92ef8ed361594aee696dfe2ea484b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-ros-py/default.nix
+++ b/distros/rolling/tf2-ros-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-xmllint, builtin-interfaces, geometry-msgs, python3Packages, rclpy, sensor-msgs, std-msgs, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-ros-py";
-  version = "0.44.0-r1";
+  version = "0.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros_py/0.44.0-1.tar.gz";
-    name = "0.44.0-1.tar.gz";
-    sha256 = "b07a21d657a21a5acb5ba6e8a1f807e9b83711d1871fa0b1c12ee85d3f006a1d";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros_py/0.45.0-1.tar.gz";
+    name = "0.45.0-1.tar.gz";
+    sha256 = "416641509eaa2e2bd006ae5fe3dc0c3fd6f4bf0e9a3e0823fefb6f57d68844da";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/tf2-ros/default.nix
+++ b/distros/rolling/tf2-ros/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, message-filters, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rosgraph-msgs, tf2, tf2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, message-filters, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rcpputils, rosgraph-msgs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tf2-ros";
-  version = "0.44.0-r1";
+  version = "0.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros/0.44.0-1.tar.gz";
-    name = "0.44.0-1.tar.gz";
-    sha256 = "91c1fc2c6267c4a914f6426464d451e37885eccc27e94f9acbf7dc674d7796f8";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros/0.45.0-1.tar.gz";
+    name = "0.45.0-1.tar.gz";
+    sha256 = "1ac976b101603d170cc16341a71ee36d741bf2c975475ec484b0176f30df9bdb";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common rosgraph-msgs ];
-  propagatedBuildInputs = [ builtin-interfaces geometry-msgs message-filters rcl-interfaces rclcpp rclcpp-action rclcpp-components tf2 tf2-msgs ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs message-filters rcl-interfaces rclcpp rclcpp-action rclcpp-components rcpputils tf2 tf2-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/tf2-sensor-msgs/default.nix
+++ b/distros/rolling/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometry-msgs, python3Packages, rclcpp, sensor-msgs, sensor-msgs-py, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-sensor-msgs";
-  version = "0.44.0-r1";
+  version = "0.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_sensor_msgs/0.44.0-1.tar.gz";
-    name = "0.44.0-1.tar.gz";
-    sha256 = "8ffef2a4b40662ff0fbb7b72eae13a9a4653f0e585fdb017dddb5a8d71c30946";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_sensor_msgs/0.45.0-1.tar.gz";
+    name = "0.45.0-1.tar.gz";
+    sha256 = "874514cc32cfb280bd2fd13c4c3351d60fcd74033a2ea61501050e3827049ecb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-tools/default.nix
+++ b/distros/rolling/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, graphviz, python3Packages, rclpy, tf2-msgs, tf2-py, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-tools";
-  version = "0.44.0-r1";
+  version = "0.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_tools/0.44.0-1.tar.gz";
-    name = "0.44.0-1.tar.gz";
-    sha256 = "ce490fa923bf0b47f70d7f263e858d4d607a60a04c2e800a282294ee88902aca";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_tools/0.45.0-1.tar.gz";
+    name = "0.45.0-1.tar.gz";
+    sha256 = "d24093ddd5e831ccfed637ebd0b75faa444ff49653a513c300d4235b6598e6b4";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/tf2/default.nix
+++ b/distros/rolling/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, builtin-interfaces, geometry-msgs, rcutils, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-rolling-tf2";
-  version = "0.44.0-r1";
+  version = "0.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2/0.44.0-1.tar.gz";
-    name = "0.44.0-1.tar.gz";
-    sha256 = "04fd4b5cc156bd66e5f24551b77658a5909ef4abdbd1ed5fb94e64c73686592f";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2/0.45.0-1.tar.gz";
+    name = "0.45.0-1.tar.gz";
+    sha256 = "b9122cdc0cf487e9b6e565f10354ac5677686050094265702e38751cbba7e9f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tile-map/default.nix
+++ b/distros/rolling/tile-map/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, glew, jsoncpp, mapviz, pluginlib, qt5, rclcpp, swri-math-util, swri-transform-util, tf2, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-tile-map";
-  version = "2.5.8-r1";
+  version = "2.5.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/tile_map/2.5.8-1.tar.gz";
-    name = "2.5.8-1.tar.gz";
-    sha256 = "db11470bf1c7d3689e713a5fdce35fea177e62ed7a63392073ff73089303c42b";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/tile_map/2.5.10-1.tar.gz";
+    name = "2.5.10-1.tar.gz";
+    sha256 = "1ea34f1aacc64bb3d4314303939ab5d1c477db15a49815de5fe58345d6d2cb15";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/transmission-interface/default.nix
+++ b/distros/rolling/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, fmt, hardware-interface, pluginlib, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-transmission-interface";
-  version = "5.5.0-r1";
+  version = "5.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "82a75e504a0ea4a8954bd3a249c449b5a55ada5d799a0461c77434de4285a578";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/5.6.0-1.tar.gz";
+    name = "5.6.0-1.tar.gz";
+    sha256 = "67338ca44d7b7471cc528766ec1d08befcb0062def7d1ca0d314a5063438173c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-controller/default.nix
+++ b/distros/rolling/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-controller";
-  version = "5.5.0-r1";
+  version = "5.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "f9228bef7c2bd6bb0cf0f6d5cdba6a216569e66637f98f185edb9940d34c4f53";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "c6253897a5f5d5f1b13cd8abc3095884c145e943d94f3cd50ec1b3ff4ce255f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-steering-controller/default.nix
+++ b/distros/rolling/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-steering-controller";
-  version = "5.5.0-r1";
+  version = "5.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "bd8b2a244aaffe1191cacd120bba7dfe3996485a6c161fb16636ca1bde2d0a4e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "a6f79159635e655a026a8a558c9710f5da58b1dd8a7e22036b0749e30df6c4dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/turtle-nest/default.nix
+++ b/distros/rolling/turtle-nest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, python3, python3Packages, qt5, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-rolling-turtle-nest";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtle_nest-release/archive/release/rolling/turtle_nest/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "f75ea7c2db021f21083ba52ad99739470e824be4c742d6704fc149ac3adbc6c7";
+    url = "https://github.com/ros2-gbp/turtle_nest-release/archive/release/rolling/turtle_nest/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "bc764db92a6d01762cae78a752519ddeb822c70394017a4c5ac356d3da7aa4e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/velocity-controllers/default.nix
+++ b/distros/rolling/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-velocity-controllers";
-  version = "5.5.0-r1";
+  version = "5.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/5.5.0-1.tar.gz";
-    name = "5.5.0-1.tar.gz";
-    sha256 = "db0c9056b802053a51812372ee31a96b50eb23499a53608b39c0e467890ca74d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/5.6.1-1.tar.gz";
+    name = "5.6.1-1.tar.gz";
+    sha256 = "c80dc7929987eea7ce66e1c4bdf8956fb3bad9a5a8b1ea5e0f4bccc3014cc4f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/web-video-server/default.nix
+++ b/distros/rolling/web-video-server/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, async-web-server-cpp, cv-bridge, ffmpeg, image-transport, pkg-config, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, async-web-server-cpp, boost, cv-bridge, ffmpeg, image-transport, pkg-config, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-web-video-server";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/web_video_server-release/archive/release/rolling/web_video_server/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "7db042c6f48789731c591c21859fcf29159ed5ff899cf27a948cb312564449e1";
+    url = "https://github.com/ros2-gbp/web_video_server-release/archive/release/rolling/web_video_server/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "e731ed5746e64443b1bda74d4b5f72fe72ca3215c0f98339cebe0afc5ccd3b31";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros pkg-config ];
   checkInputs = [ ament-cmake-copyright ament-cmake-cpplint ament-cmake-lint-cmake ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ros-environment ];
-  propagatedBuildInputs = [ async-web-server-cpp cv-bridge ffmpeg image-transport rclcpp rclcpp-components sensor-msgs ];
+  propagatedBuildInputs = [ async-web-server-cpp boost cv-bridge ffmpeg image-transport rclcpp rclcpp-components sensor-msgs ];
   nativeBuildInputs = [ ament-cmake-ros pkg-config ];
 
   meta = {

--- a/distros/rolling/xacro/default.nix
+++ b/distros/rolling/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-index-python, ament-lint-auto, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-xacro";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/xacro-release/archive/release/rolling/xacro/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "50d9b89c0fbcc36efe749abb384df9196294dfd975070da3e649f0f78d629217";
+    url = "https://github.com/ros2-gbp/xacro-release/archive/release/rolling/xacro/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "38818feea13f23a1c5b06bb7c83f78fe6c7d534469319b1db231b3a2d630dd55";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/yasmin-demos/default.nix
+++ b/distros/rolling/yasmin-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, example-interfaces, nav-msgs, python3Packages, rclcpp, rclpy, ros-environment, yasmin, yasmin-ros, yasmin-viewer }:
 buildRosPackage {
   pname = "ros-rolling-yasmin-demos";
-  version = "3.3.0-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/rolling/yasmin_demos/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "dc4e9274e5a2a810ae610bae0a6ee3ce55b5be617d665db8f66c75595f17dc29";
+    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/rolling/yasmin_demos/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "cca1f521364610d57a0d80115e5d68f2ee07b2ced6a593157b09b73a5e6f4686";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/yasmin-msgs/default.nix
+++ b/distros/rolling/yasmin-msgs/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-rolling-yasmin-msgs";
-  version = "3.3.0-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/rolling/yasmin_msgs/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "fb891a110e9b71d3cb1b86266fb9c9b07a3ff3d8eac6d4892c5dd9df84fb9fac";
+    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/rolling/yasmin_msgs/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "58fb304bffa4cf3fcf1d8c3d79eddacdcc419037d5a569667d641994ab80bbe5";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ rosidl-default-generators ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/yasmin-ros/default.nix
+++ b/distros/rolling/yasmin-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, python3Packages, rclcpp, rclcpp-action, rclpy, ros-environment, yasmin }:
 buildRosPackage {
   pname = "ros-rolling-yasmin-ros";
-  version = "3.3.0-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/rolling/yasmin_ros/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "febd6aee4b9edb02e77a94777f6ae9c31f7a44f4e902c57b55cf371e0a94ba4f";
+    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/rolling/yasmin_ros/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "ff0701f889581e31eaf10be7d5b0d7953b65ce02b9c521d6a865369ecf637424";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/yasmin-viewer/default.nix
+++ b/distros/rolling/yasmin-viewer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, python3Packages, rclcpp, rclpy, yasmin, yasmin-msgs, yasmin-ros }:
 buildRosPackage {
   pname = "ros-rolling-yasmin-viewer";
-  version = "3.3.0-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/rolling/yasmin_viewer/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "ac1415bf7ee62976651030de72134bbcb67a0cbe26589c3f6c46def53dbbc308";
+    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/rolling/yasmin_viewer/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "baf3d6ebdefebc3c29aceca4b8fa50ef3786ad4738ee5b6bc6e9abbed241d021";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/yasmin/default.nix
+++ b/distros/rolling/yasmin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-yasmin";
-  version = "3.3.0-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/rolling/yasmin/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "85aea1e7534ab6ec0b73ad7770f290bc37cb8633fa9f231dff865b4df9756b69";
+    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/rolling/yasmin/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "c3c4fe84d3366ad79fa1c7616c2b9a9806d6dc2c6591bcb7c6465ca05dc6d6ff";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'kilted', 'rolling'] from nix-ros-overlay commit b4915dfe2232df424e4aad42e7fa150da93059e9.
This pull request was generated by running the following command:

```
superflore-gen-nix --dry-run --output-repository-path . --all --tar-archive-dir /home/runner/.ros/tar --upstream-branch develop
```

Changes:
========
Humble Changes:
---------------
* *async-web-server-cpp 2.0.0-r3 --> 2.0.1-r1*
* *at-sonde-ros-driver 1.0.0-r1*
* *automatika-embodied-agents 0.4.1-r1 --> 0.4.2-r1*
* *launch-pal 0.14.1-r1 --> 0.17.0-r1*
* *mapviz 2.5.9-r1 --> 2.5.10-r1*
* *mapviz-interfaces 2.5.9-r1 --> 2.5.10-r1*
* *mapviz-plugins 2.5.9-r1 --> 2.5.10-r1*
* *multires-image 2.5.9-r1 --> 2.5.10-r1*
* *tile-map 2.5.9-r1 --> 2.5.10-r1*

Jazzy Changes:
--------------
* *async-web-server-cpp 2.0.0-r6 --> 2.0.1-r1*
* *automatika-embodied-agents 0.4.1-r1 --> 0.4.2-r1*
* *gz-tools-vendor 0.0.6-r1 --> 0.0.7-r1*
* *mapviz 2.5.9-r1 --> 2.5.10-r1*
* *mapviz-interfaces 2.5.9-r1 --> 2.5.10-r1*
* *mapviz-plugins 2.5.9-r1 --> 2.5.10-r1*
* *multires-image 2.5.9-r1 --> 2.5.10-r1*
* *tile-map 2.5.9-r1 --> 2.5.10-r1*

Kilted Changes:
---------------
* *async-web-server-cpp 2.0.0-r6 --> 2.0.1-r1*
* *automatika-embodied-agents 0.4.1-r1 --> 0.4.2-r1*
* *depthai 3.0.3-r1 --> 3.0.4-r1*
* *depthai-bridge 3.0.4-r1 --> 3.0.5-r1*
* *depthai-descriptions 3.0.4-r1 --> 3.0.5-r1*
* *depthai-examples 3.0.4-r1 --> 3.0.5-r1*
* *depthai-filters 3.0.4-r1 --> 3.0.5-r1*
* *depthai-ros 3.0.4-r1 --> 3.0.5-r1*
* *depthai-ros-driver 3.0.4-r1 --> 3.0.5-r1*
* *depthai-ros-msgs 3.0.4-r1 --> 3.0.5-r1*
* *gz-common-vendor 0.2.3-r2 --> 0.2.5-r1*
* *gz-fuel-tools-vendor 0.2.1-r2 --> 0.2.3-r1*
* *gz-math-vendor 0.2.3-r2 --> 0.2.5-r1*
* *gz-physics-vendor 0.2.1-r2 --> 0.2.3-r1*
* *gz-rendering-vendor 0.2.1-r2 --> 0.2.4-r1*
* *gz-sensors-vendor 0.2.1-r2 --> 0.2.3-r1*
* *gz-tools-vendor 0.1.2-r2 --> 0.1.3-r1*
* *mapviz 2.5.9-r1 --> 2.5.10-r1*
* *mapviz-interfaces 2.5.9-r1 --> 2.5.10-r1*
* *mapviz-plugins 2.5.9-r1 --> 2.5.10-r1*
* *multires-image 2.5.9-r1 --> 2.5.10-r1*
* *tile-map 2.5.9-r1 --> 2.5.10-r1*

Rolling Changes:
----------------
* *ackermann-steering-controller 5.5.0-r1 --> 5.6.1-r1*
* *admittance-controller 5.5.0-r1 --> 5.6.1-r1*
* *apriltag 3.4.4-r1 --> 3.4.5-r1*
* *apriltag-detector 3.0.3-r1 --> 3.0.4-r1*
* *apriltag-detector-mit 3.0.3-r1 --> 3.0.4-r1*
* *apriltag-detector-umich 3.0.3-r1 --> 3.0.4-r1*
* *apriltag-draw 3.0.3-r1 --> 3.0.4-r1*
* *apriltag-ros 3.2.2-r1 --> 3.3.0-r1*
* *apriltag-tools 3.0.3-r1 --> 3.0.4-r1*
* *async-web-server-cpp 2.0.0-r5 --> 2.0.1-r1*
* *at-sonde-ros-driver 1.0.0-r1*
* *automatika-embodied-agents 0.4.1-r1 --> 0.4.2-r1*
* *automatika-ros-sugar 0.3.1-r1 --> 0.3.2-r1*
* *bicycle-steering-controller 5.5.0-r1 --> 5.6.1-r1*
* *camera-ros 0.4.0-r1 --> 0.5.0-r1*
* *catch-ros2 0.2.1-r1 --> 0.2.3-r1*
* *chained-filter-controller 5.6.1-r1*
* *control-msgs 6.4.0-r1 --> 6.5.0-r1*
* *controller-interface 5.5.0-r1 --> 5.6.0-r1*
* *controller-manager 5.5.0-r1 --> 5.6.0-r1*
* *controller-manager-msgs 5.5.0-r1 --> 5.6.0-r1*
* *diff-drive-controller 5.5.0-r1 --> 5.6.1-r1*
* *effort-controllers 5.5.0-r1 --> 5.6.1-r1*
* *event-camera-renderer 2.0.1-r1 --> 2.0.2-r1*
* *examples-tf2-py 0.44.0-r1 --> 0.45.0-r1*
* *ffmpeg-image-transport 3.0.0-r1 --> 3.0.3-r1*
* *force-torque-sensor-broadcaster 5.5.0-r1 --> 5.6.1-r1*
* *forward-command-controller 5.5.0-r1 --> 5.6.1-r1*
* *foxglove-compressed-video-transport 3.0.0-r1 --> 3.0.2-r1*
* *fuse 1.3.0-r1 --> 1.3.1-r1*
* *fuse-constraints 1.3.0-r1 --> 1.3.1-r1*
* *fuse-core 1.3.0-r1 --> 1.3.1-r1*
* *fuse-doc 1.3.0-r1 --> 1.3.1-r1*
* *fuse-graphs 1.3.0-r1 --> 1.3.1-r1*
* *fuse-loss 1.3.0-r1 --> 1.3.1-r1*
* *fuse-models 1.3.0-r1 --> 1.3.1-r1*
* *fuse-msgs 1.3.0-r1 --> 1.3.1-r1*
* *fuse-optimizers 1.3.0-r1 --> 1.3.1-r1*
* *fuse-publishers 1.3.0-r1 --> 1.3.1-r1*
* *fuse-tutorials 1.3.0-r1 --> 1.3.1-r1*
* *fuse-variables 1.3.0-r1 --> 1.3.1-r1*
* *fuse-viz 1.3.0-r1 --> 1.3.1-r1*
* *geometry2 0.44.0-r1 --> 0.45.0-r1*
* *gpio-controllers 5.5.0-r1 --> 5.6.1-r1*
* *gps-sensor-broadcaster 5.5.0-r1 --> 5.6.1-r1*
* *gz-physics-vendor 0.2.2-r1 --> 0.3.0-r1*
* *gz-rendering-vendor 0.2.3-r1 --> 0.3.0-r1*
* *gz-sim-vendor 0.2.1-r1 --> 0.3.0-r1*
* *gz-tools-vendor 0.1.2-r1 --> 0.2.0-r1*
* *hardware-interface 5.5.0-r1 --> 5.6.0-r1*
* *hardware-interface-testing 5.5.0-r1 --> 5.6.0-r1*
* *imu-sensor-broadcaster 5.5.0-r1 --> 5.6.1-r1*
* *joint-limits 5.5.0-r1 --> 5.6.0-r1*
* *joint-state-broadcaster 5.5.0-r1 --> 5.6.1-r1*
* *joint-trajectory-controller 5.5.0-r1 --> 5.6.1-r1*
* *kinematics-interface 2.1.0-r1 --> 2.2.0-r1*
* *kinematics-interface-kdl 2.1.0-r1 --> 2.2.0-r1*
* *kompass 0.3.0-r1 --> 0.3.1-r1*
* *kompass-interfaces 0.3.0-r1 --> 0.3.1-r1*
* *libcaer-driver 1.5.2-r1 --> 1.5.3-r1*
* *mapviz 2.5.8-r1 --> 2.5.10-r1*
* *mapviz-interfaces 2.5.8-r1 --> 2.5.10-r1*
* *mapviz-plugins 2.5.8-r1 --> 2.5.10-r1*
* *mecanum-drive-controller 5.5.0-r1 --> 5.6.1-r1*
* *mola-common 0.4.1-r1 --> 0.5.0-r1*
* *mola-lidar-odometry 0.8.0-r1 --> 0.9.0-r1*
* *motion-primitives-controllers 5.6.1-r1*
* *mp2p-icp 1.7.1-r1 --> 1.8.0-r1*
* *mrpt-apps 2.14.11-r1 --> 2.14.12-r1*
* *mrpt-libapps 2.14.11-r1 --> 2.14.12-r1*
* *mrpt-libbase 2.14.11-r1 --> 2.14.12-r1*
* *mrpt-libgui 2.14.11-r1 --> 2.14.12-r1*
* *mrpt-libhwdrivers 2.14.11-r1 --> 2.14.12-r1*
* *mrpt-libmaps 2.14.11-r1 --> 2.14.12-r1*
* *mrpt-libmath 2.14.11-r1 --> 2.14.12-r1*
* *mrpt-libnav 2.14.11-r1 --> 2.14.12-r1*
* *mrpt-libobs 2.14.11-r1 --> 2.14.12-r1*
* *mrpt-libopengl 2.14.11-r1 --> 2.14.12-r1*
* *mrpt-libposes 2.14.11-r1 --> 2.14.12-r1*
* *mrpt-libros-bridge 2.14.11-r1 --> 2.14.12-r1*
* *mrpt-libslam 2.14.11-r1 --> 2.14.12-r1*
* *mrpt-libtclap 2.14.11-r1 --> 2.14.12-r1*
* *multires-image 2.5.8-r1 --> 2.5.10-r1*
* *omni-wheel-drive-controller 5.5.0-r1 --> 5.6.1-r1*
* *parallel-gripper-controller 5.5.0-r1 --> 5.6.1-r1*
* *pid-controller 5.5.0-r1 --> 5.6.1-r1*
* *pose-broadcaster 5.5.0-r1 --> 5.6.1-r1*
* *position-controllers 5.5.0-r1 --> 5.6.1-r1*
* *range-sensor-broadcaster 5.5.0-r1 --> 5.6.1-r1*
* *robot-localization 3.9.3-r1 --> 3.10.0-r2*
* *robotraconteur 1.2.5-r1 --> 1.2.6-r1*
* *ros2-control 5.5.0-r1 --> 5.6.0-r1*
* *ros2-control-test-assets 5.5.0-r1 --> 5.6.0-r1*
* *ros2-controllers 5.5.0-r1 --> 5.6.1-r1*
* *ros2-controllers-test-nodes 5.5.0-r1 --> 5.6.1-r1*
* *ros2controlcli 5.5.0-r1 --> 5.6.0-r1*
* *rqt-controller-manager 5.5.0-r1 --> 5.6.0-r1*
* *rqt-joint-trajectory-controller 5.5.0-r1 --> 5.6.1-r1*
* *rqt-robot-steering 4.0.0-r1 --> 4.0.2-r1*
* *rviz-common 15.1.8-r1 --> 15.1.9-r1*
* *rviz-default-plugins 15.1.8-r1 --> 15.1.9-r1*
* *rviz-ogre-vendor 15.1.8-r1 --> 15.1.9-r1*
* *rviz-rendering 15.1.8-r1 --> 15.1.9-r1*
* *rviz-rendering-tests 15.1.8-r1 --> 15.1.9-r1*
* *rviz-resource-interfaces 15.1.8-r1 --> 15.1.9-r1*
* *rviz-visual-testing-framework 15.1.8-r1 --> 15.1.9-r1*
* *rviz2 15.1.8-r1 --> 15.1.9-r1*
* *septentrio-gnss-driver 1.4.4-r1 --> 1.4.5-r1*
* *steering-controllers-library 5.5.0-r1 --> 5.6.1-r1*
* *tf2 0.44.0-r1 --> 0.45.0-r1*
* *tf2-2d 1.6.0-r1 --> 1.6.1-r1*
* *tf2-bullet 0.44.0-r1 --> 0.45.0-r1*
* *tf2-eigen 0.44.0-r1 --> 0.45.0-r1*
* *tf2-eigen-kdl 0.44.0-r1 --> 0.45.0-r1*
* *tf2-geometry-msgs 0.44.0-r1 --> 0.45.0-r1*
* *tf2-kdl 0.44.0-r1 --> 0.45.0-r1*
* *tf2-msgs 0.44.0-r1 --> 0.45.0-r1*
* *tf2-py 0.44.0-r1 --> 0.45.0-r1*
* *tf2-ros 0.44.0-r1 --> 0.45.0-r1*
* *tf2-ros-py 0.44.0-r1 --> 0.45.0-r1*
* *tf2-sensor-msgs 0.44.0-r1 --> 0.45.0-r1*
* *tf2-tools 0.44.0-r1 --> 0.45.0-r1*
* *tile-map 2.5.8-r1 --> 2.5.10-r1*
* *transmission-interface 5.5.0-r1 --> 5.6.0-r1*
* *tricycle-controller 5.5.0-r1 --> 5.6.1-r1*
* *tricycle-steering-controller 5.5.0-r1 --> 5.6.1-r1*
* *turtle-nest 1.1.0-r1 --> 1.2.0-r1*
* *velocity-controllers 5.5.0-r1 --> 5.6.1-r1*
* *web-video-server 2.1.0-r1 --> 2.1.1-r1*
* *xacro 2.1.0-r1 --> 2.1.1-r1*
* *yasmin 3.3.0-r1 --> 3.4.0-r1*
* *yasmin-demos 3.3.0-r1 --> 3.4.0-r1*
* *yasmin-msgs 3.3.0-r1 --> 3.4.0-r1*
* *yasmin-ros 3.3.0-r1 --> 3.4.0-r1*
* *yasmin-viewer 3.3.0-r1 --> 3.4.0-r1*


Missing Dependencies:
=====================
 * [ ] action_tutorials_interfaces
 * [ ] actionlib_msgs
 * [ ] gazebo_ros2_control
 * [ ] gazebo_ros_pkgs
 * [ ] gripper_controllers
 * [ ] gurumdds-3.0
 * [ ] gurumdds-3.2
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] libopen3d-dev
 * [ ] libserial-dev
 * [ ] nanobind-dev
 * [ ] pybind11-json-dev
 * [ ] pybind11_json_vendor
 * [ ] python-is-python3
 * [ ] python3-jsonpickle
 * [ ] python3-pymap3d
 * [ ] python3-pytorch-pip
 * [ ] python3-torch-geometric-pip
 * [ ] python3-typer
 * [ ] python3-types-pyyaml
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo