### PR TITLE
inherit tsid from nixpkgs

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -206,6 +206,10 @@ let
       '';
     });
 
+    # vcstool was replaced by vcs2l in nixpkgs (https://github.com/NixOS/nixpkgs/pull/499630)
+    # TODO: Make this change in rosdep after master is moved to nixpkgs without vcstool.
+    vcstool = self.vcs2l;
+
   } // (mrptOverrides rosSelf rosSuper);
 
   otherSplices = {

--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -91,7 +91,7 @@ let
 
     # Some third-party packages are available in rodistro,
     # but have a better packaging in nixpkgs, so use it instead
-    inherit (self.python3Packages) coal eigenpy pinocchio crocoddyl ;
+    inherit (self.python3Packages) coal eigenpy pinocchio crocoddyl tsid;
 
     freeimage = null; # Get rid of freeimage
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771369470,
-        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0182a361324364ae3f436a63005877674cf45efb",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
same as https://github.com/lopsided98/nix-ros-overlay/issues/536

fix `callPackageWith: Function called without required argument "_unresolved_pinocchio"` for lyrical.tsid